### PR TITLE
Store moods in DB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ jobs:
     before_script: gunicorn main:app &
     script: pytest
     env:
-        - ALLOW_ORIGINS='*'
+    - ALLOW_ORIGINS='*'
+    - secure: HWnGYgH/OXujLzdnk74A8npCVYUW9YXTb0ylPM8Cx8HkqnvQrULSrMwMnzjut/gv2hQEmf4QR85EdDWwp6q6VMrNNOUq3+ozNTO2KLJYOry1XNXW9FNuX77FU0NfLeszJsqd9Qv+FVbkjFdWpd1QgbXZs7EzaY09WWNUTPXwUhHtfrctT1JbWQk4XUYCsv8+ty7mbXYl+8lDMckfndtu7shPi0cVcndQk4fIfsQgyB6nOQzsWh4srdDSRwWNvCxvFSL1WXkG2NZnx4uxne3bGaV153BmyxiN9lmUQ4gqmvLVcgNTn/DhRwSP0+Bv1+S6WrSNgIqpUhcA0EvRnazSwUljmeIQQCZ1Lxy+9q6/GS+KHfY3l64alsZ26FoL6QTlAXyOeEpjJAyL22oVgDAP+Yw6YrcHNtqdHlPP8C78+4c7EoXwAlm/LLZNUfutF/YpXseVFYfP/WGYOf+vDXtvuWvlzVUokT5ETErtZTu6Aq/8WWQzQdiKv6mCBCsBl5Fatt8PQhoq0iinmmFT2sS19Aa0hqXRTqp1J4k40ykWUiQJXkzakwMsk31R/Kr/WfFi5RT8xVMWALA9CxHe1IlXPD+rp/fvnQhXANa/fs13iAyHh8B8xNz2iVPxi0Om3lcO1ocm+1tGtYsGEyFFxlky2pg0gidig/alufr0zD/TCKg=
 deploy:
   - provider: heroku
     app: musaic-13018

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -89,10 +89,6 @@ def extract_credentials():
         return jsonify({'error': 'Access Token expired'})
     g.user_id = payload['user_id']
     g.access_token = payload['access_token']
-    print(g.user_id)
-    print(g.access_token)
-
-
 
 
 def create_jwt(access_token, user_id, expires_in):

--- a/backend/mood.py
+++ b/backend/mood.py
@@ -1,29 +1,14 @@
 from flask import Blueprint, request, abort, jsonify, Response, g
-from marshmallow import Schema, fields, validate, exceptions
+from marshmallow import exceptions
 import copy
 import json
 from .auth import extract_credentials
+from .mood_generator import MoodGenerator, CreateOrUpdateMoodStrategy, \
+		GetMoodFromDBStrategy, DeleteMoodFromDBStrategy
 
 mood_api = Blueprint('mood_api', __name__)
 mood_api.before_request(extract_credentials)
 
-# TODO: use non-volatile memory to preserve moods even if server crashes
-mood_cache = {}
-
-# (Create or Update) Mood Schema
-class CreateUpdateMood(Schema):
-	seed_artists = fields.List(fields.String(), required=True, validate=validate.Length(min=1))
-	seed_genres = fields.List(fields.String(), required=True, validate=validate.Length(min=1))
-	seed_tracks = fields.List(fields.String(), required=True, validate=validate.Length(min=1))
-
-	# each is num list [min, max, target]
-	# TODO: check if min < target < max
-	danceability = fields.List(fields.Number(), required=False, validate=validate.Length(equal=3))
-	instrumentalness = fields.List(fields.Number(), required=False, validate=validate.Length(equal=3))
-	popularity = fields.List(fields.Number(), required=False, validate=validate.Length(equal=3))
-	speechiness = fields.List(fields.Number(), required=False, validate=validate.Length(equal=3))
-	valence = fields.List(fields.Number(), required=False, validate=validate.Length(equal=3))
-	energy = fields.List(fields.Number(), required=False, validate=validate.Length(equal=3))
 
 # Create OR update mood (PUT request)
 @mood_api.route("/mood", methods=['PUT'])
@@ -37,15 +22,14 @@ def create_update_custom_mood():
 
 	# Request body validation
 	# Reference: https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-recommendations
+	data = request.data.decode("utf8")
+	generator = MoodGenerator(name, g.user_id, data, CreateOrUpdateMoodStrategy)
 	try:
-		data = CreateUpdateMood().loads(request.data.decode("utf8"))
+		mood = generator.generate()
 	except exceptions.ValidationError as err:
 		abort(422, description="Unprocessable entity: " + str(err.messages))
 
-	user = g.user_id
-	if user not in mood_cache:
-		mood_cache[user] = {}
-	mood_cache[user][name] = data
+	data = mood.params
 
 	print(data)
 	return jsonify(data)
@@ -60,13 +44,11 @@ def delete_custom_mood():
 	if name is None:
 		abort(422, description="Unprocessable entity: missing mood name query string")
 
-	user = g.user_id
-	# Don't bother checking if mood actually exists
-	# Only need to delete if it exists
-	if user in mood_cache and name in mood_cache[user]:
-		mood_to_del = copy.deepcopy(mood_cache[user][name])
-		del mood_cache[user][name]
-		return jsonify(mood_to_del)
+	generator = MoodGenerator(name, g.user_id, None, DeleteMoodFromDBStrategy)
+	mood = generator.generate()
+
+	if not mood is None:
+		return jsonify(mood.params)
 	return Response(status = 200)
 
 # Read mood (GET request)
@@ -79,7 +61,9 @@ def get_custom_mood():
 	if name is None:
 		abort(422, description="Unprocessable entity: missing mood name query string")
 
-	user = g.user_id
-	if user in mood_cache and name in mood_cache[user]:
-		return jsonify(mood_cache[user][name])
+	generator = MoodGenerator(name, g.user_id, None, GetMoodFromDBStrategy)
+	mood = generator.generate()
+
+	if not mood is None:
+		return jsonify(mood.params)
 	return Response(status = 404)

--- a/backend/mood_generator.py
+++ b/backend/mood_generator.py
@@ -1,0 +1,84 @@
+from .utils.db import DB
+from marshmallow import Schema, fields, validate
+
+class MoodSchema(Schema):
+    seed_artists = fields.List(fields.String(), validate=validate.Length(min=1))
+    seed_genres = fields.List(fields.String(), validate=validate.Length(min=1))
+    seed_tracks = fields.List(fields.String(), validate=validate.Length(min=1))
+    
+    # each is num list [min, max, target]
+    # TODO: check if min < target < max
+    danceability = fields.List(fields.Number(), validate=validate.Length(equal=3))
+    instrumentalness = fields.List(fields.Number(), validate=validate.Length(equal=3))
+    popularity = fields.List(fields.Number(), validate=validate.Length(equal=3))
+    speechiness = fields.List(fields.Number(), validate=validate.Length(equal=3))
+    valence = fields.List(fields.Number(), validate=validate.Length(equal=3))
+    energy = fields.List(fields.Number(), validate=validate.Length(equal=3))
+
+
+class Mood:
+    def __init__(self, name, creator_id, params, mood_id):
+        self.name = name
+        self.creator_id = creator_id
+        self.params = params
+        self.mood_id = mood_id
+    
+
+class MoodGenerator:
+    def __init__(self, name, creator_id, params, strategy):
+        self.name = name
+        self.creator_id = creator_id
+        self.params = params
+        self.strategy = strategy
+
+    def set_strategy(self, strategy):
+        self.strategy = strategy
+
+    def generate(self):
+        return self.strategy(self.name, self.creator_id, self.params).generate()
+
+
+class GenerationStrategy:
+    def __init__(self, name, creator_id, params):
+        self.name = name
+        self.creator_id = creator_id
+        self.params = params
+    
+    def generate(self):
+        raise NotImplementedError
+
+
+class CreateOrUpdateMoodStrategy(GenerationStrategy):
+    def generate(self):
+        deserialized = MoodSchema().loads(\
+                {} if self.params is None else self.params)
+        mood_id = None
+        with DB() as db:
+            mood_id, _ = db.get_mood_by_name(self.name, self.creator_id)
+            create_or_update = None
+            if mood_id is None:
+                create_or_update = db.create_mood
+            else:
+                create_or_update = db.update_mood
+            mood_id = create_or_update(self.name, self.creator_id, self.params)
+        return Mood(self.name, self.creator_id, deserialized, mood_id)
+
+
+class GetMoodFromDBStrategy(GenerationStrategy):
+    def generate(self):
+        mood_id, params = None, None
+        with DB() as db:
+            mood_id, params = db.get_mood_by_name(self.name, self.creator_id)
+        if mood_id is None:
+            return None
+        return Mood(self.name, self.creator_id, params, mood_id)
+
+
+class DeleteMoodFromDBStrategy(GenerationStrategy):
+    def generate(self):
+        mood_id, params = None, None
+        with DB() as db:
+            mood_id, params = db.delete_mood(self.name, self.creator_id)
+        if mood_id is None:
+            return None
+        return Mood(self.name, self.creator_id, params, mood_id)

--- a/backend/utils/db.py
+++ b/backend/utils/db.py
@@ -1,0 +1,67 @@
+import psycopg2
+from psycopg2.extras import Json
+import os
+
+class DB:
+    def __init__(self):
+        self._conn = psycopg2.connect(os.environ['DATABASE_URL'], sslmode='require')
+        self._cursor = self._conn.cursor()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self._conn.commit()
+        self._cursor.close()
+        self._conn.close()
+
+    def initialize(self):
+        create_moods = (
+                "CREATE TABLE IF NOT EXISTS Moods ("
+                "mood_id serial,"
+                "name varchar,"
+                "creator_id varchar,"
+                "params json,"
+                "PRIMARY KEY (name, creator_id)"
+                ");"
+                )
+        self._cursor.execute(create_moods)
+        #TODO: Create Users and Playlists tables
+
+    def create_mood(self, name, creator_id, params):
+        insert = (
+                "INSERT INTO Moods("
+                "name, creator_id, params"
+                ") values (%s, %s, %s) RETURNING mood_id;" 
+                )
+        params = Json(params)
+        self._cursor.execute(insert, (name, creator_id, params)) 
+        return self._cursor.fetchone()[0]
+
+    def update_mood(self, name, creator_id, params):
+        update = (
+                "UPDATE Moods SET params = %s "
+                "WHERE name = %s AND creator_id = %s RETURNING mood_id;"
+                )
+        self._cursor.execute(update, (params, name, creator_id))
+        return self._cursor.fetchone()[0]
+
+    def get_mood_by_name(self, name, creator_id):
+        select = (
+                "SELECT * FROM Moods WHERE name = %s AND creator_id = %s;"
+                )
+        self._cursor.execute(select, (name, creator_id))
+        row = self._cursor.fetchone()
+        if row is None:
+            return None, None
+        return row[0], row[3]
+
+    def delete_mood(self, name, creator_id):
+        delete = (
+                "DELETE FROM Moods WHERE name = %s AND creator_id = %s RETURNING *;"
+                )
+        self._cursor.execute(delete, (name, creator_id))
+        row = self._cursor.fetchone()
+        if row is None:
+            return None, None
+        return row[0], row[3]

--- a/main.py
+++ b/main.py
@@ -3,11 +3,16 @@ from flask_cors import CORS
 from os import environ
 from backend.mood import mood_api
 from backend.auth import auth_api
+from backend.utils.db import DB
+
+with DB() as db:
+    db.initialize()
 
 app = Flask(__name__)
 CORS(app, resources={r"/*" : {"origins": environ['ALLOW_ORIGINS']}})
 app.register_blueprint(mood_api, url_prefix='/api/v1/mood')
 app.register_blueprint(auth_api, url_prefix='/login')
+
 
 @app.route("/")
 def hello():

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ MarkupSafe==1.1.1
 marshmallow==3.10.0
 packaging==20.9
 pluggy==0.13.1
+psycopg2-binary==2.8.6
 py==1.10.0
 PyJWT==2.0.1
 pyparsing==2.4.7


### PR DESCRIPTION
- Create DB "façade" interface
- Create Mood class that wraps mood data
- Create Mood generator and generation strategies
   - Strategies include: 
      - Create Or Update strategy (mood not yet in DB)
      - Delete Strategy (returns mood after deleting from DB)
      - Get strategy (returns mood that is stored in DB)
   - These strategies are used in the Mood api endpoints as appropriate
- Add Database URL to .travis.yml