### PR TITLE
Be/arjun/playlist generation

### DIFF
--- a/backend/mood.py
+++ b/backend/mood.py
@@ -8,13 +8,15 @@ mood_api = Blueprint('mood_api', __name__)
 mood_api.before_request(extract_credentials)
 
 # TODO: use non-volatile memory to preserve moods even if server crashes
+# Change to use DBFacade
 mood_cache = {}
 
 # (Create or Update) Mood Schema
 class CreateUpdateMood(Schema):
-	seed_artists = fields.List(fields.String(), required=True, validate=validate.Length(min=1))
-	seed_genres = fields.List(fields.String(), required=True, validate=validate.Length(min=1))
-	seed_tracks = fields.List(fields.String(), required=True, validate=validate.Length(min=1))
+	# no longer requiring seed tracks
+	seed_artists = fields.List(fields.String(), required=False, validate=validate.Length(min=1))
+	seed_genres = fields.List(fields.String(), required=False, validate=validate.Length(min=1))
+	seed_tracks = fields.List(fields.String(), required=False, validate=validate.Length(min=1))
 
 	# each is num list [min, max, target]
 	# TODO: check if min < target < max

--- a/backend/spotify_facade.py
+++ b/backend/spotify_facade.py
@@ -1,0 +1,64 @@
+import requests
+from enum import Enum
+from flask import Blueprint
+
+class Constants(Enum):
+	LIMIT = '10'
+	MARKET = 'US'
+	OFFSET = '0'
+
+	SPOTIFY_SEARCH = 'https://api.spotify.com/v1/search'
+	SPOTIFY_RECOMMENDATIONS = 'https://api.spotify.com/v1/recommendations'
+
+spotify_api = Blueprint('spotify_api', __name__)
+
+# Reference: 
+def get_tracks(mood, authorization, **kwargs):
+	get_args = {}
+	if 'limit' not in kwargs:
+		get_args['limit'] = Constants.LIMIT
+	if 'market' not in kwargs:
+		get_args['market'] = Constants.MARKET
+	for k, v in mood.items():
+		# separate Spotify parameters
+		if 'seed' not in k:
+			get_args['min_' + k] = v[0]
+			get_args['max_' + k] = v[1]
+			get_args['target_' + k] = v[2]
+		else:	# seed parameters
+			get_args[k] = v
+
+	# TODO: how to get OAuth access token?
+	oauth_access_token = ''
+	headers = {'Accept': 'application/json', 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + oauth_access_token}
+
+	return requests.get(Constants.SPOTIFY_RECOMMENDATIONS, params=get_args, headers=headers).json()
+
+# Reference: https://developer.spotify.com/documentation/web-api/reference/#endpoint-search
+@spotify_api.route("/search", methods=['GET'])
+def get_spotify_id():
+	if not request.args:
+		abort(400, description="Malformed syntax")
+
+	if request.args.get('query') is None: # ?query = query string
+		abort(422, description="Unprocessable entity: missing query")
+
+	if request.args.get('type') is None: # ?type = query string (artist, genre, or track)
+		abort(422, description="Unprocessable entity: missing query type")
+
+	get_args = {}
+	if 'limit' not in request.args:
+		get_args['limit'] = Constants.LIMIT
+	if 'market' not in request.args:
+		get_args['market'] = Constants.MARKET
+	if 'offset' not in request.args:
+		get_args['offset'] = Constants.OFFSET
+	for k, v in request.args.items():
+		get_args[k] = v
+
+	# TODO: how to get OAuth access token?
+	oauth_access_token = ''
+	headers = {'Accept': 'application/json', 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + oauth_access_token}
+
+	return requests.get(Constants.SPOTIFY_SEARCH, params=get_args, headers=headers).json()
+

--- a/backend/spotify_facade.py
+++ b/backend/spotify_facade.py
@@ -46,30 +46,30 @@ def get_playlist_from_mood(mood_name, **kwargs):
 		# Reference: https://developer.spotify.com/console/get-current-user-top-artists-and-tracks/
 		top_artists = requests.get(Constants.SPOTIFY_TOP_ARTISTS_AND_TRACKS.format('artists'), params={'limit': Constants.LIMIT}, headers=headers)
 		if not top_artists.ok:
-	      print(top_artists.text)
-	      abort(500, "Error in retrieving user's top artists")
-	  top_artists = top_artists.json()
-	  seed_artists = []
-	  top_genres = set()
-	  for artist in top_artists['items']:
-	  	seed_artists.append(artist['id'])
-	  	top_genres.update(artist['genres'])
+			print(top_artists.text)
+			abort(500, "Error in retrieving user's top artists")
+		top_artists = top_artists.json()
+		seed_artists = []
+		top_genres = set()
+		for artist in top_artists['items']:
+			seed_artists.append(artist['id'])
+			top_genres.update(artist['genres'])
 
-	  if 'seed_artists' not in get_args:
-	  	get_args['seed_artists'] = seed_artists
-	  if 'seed_genres' not in get_args
-	  	get_args['top_genres'] = list(top_genres)
+		if 'seed_artists' not in get_args:
+			get_args['seed_artists'] = seed_artists
+		if 'seed_genres' not in get_args
+			get_args['top_genres'] = list(top_genres)
 
 	if 'seed_tracks' not in get_args:
 		# Reference: https://developer.spotify.com/console/get-current-user-top-artists-and-tracks/
-	  top_tracks = requests.get(Constants.SPOTIFY_TOP_ARTISTS_AND_TRACKS.format('tracks'), params={'limit': Constants.LIMIT}, headers=headers)
-	  if not top_tracks.ok:
-	      print(top_tracks.text)
-	      abort(500, "Error in retrieving user's top tracks")
-	  top_tracks = top_tracks.json()
-	  get_args['seed_tracks'] = []
-	  for track in top_tracks['items']:
-	  	get_args['seed_tracks'].append(track['id'])
+		top_tracks = requests.get(Constants.SPOTIFY_TOP_ARTISTS_AND_TRACKS.format('tracks'), params={'limit': Constants.LIMIT}, headers=headers)
+		if not top_tracks.ok:
+			print(top_tracks.text)
+			abort(500, "Error in retrieving user's top tracks")
+		top_tracks = top_tracks.json()
+		get_args['seed_tracks'] = []
+		for track in top_tracks['items']:
+			get_args['seed_tracks'].append(track['id'])
 
 	return requests.get(Constants.SPOTIFY_RECOMMENDATIONS, params=get_args, headers=headers).json()
 
@@ -99,4 +99,3 @@ def get_spotify_id():
 	headers = {'Accept': 'application/json', 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + oauth_access_token}
 
 	return requests.get(Constants.SPOTIFY_SEARCH, params=get_args, headers=headers).json()
-

--- a/backend/spotify_facade.py
+++ b/backend/spotify_facade.py
@@ -78,6 +78,7 @@ def get_playlist_from_mood():
 		for track in top_tracks['items']:
 			get_args['seed_tracks'].append(track['id'])
 
+	print(get_args)
 	return requests.get(Constants.SPOTIFY_RECOMMENDATIONS.value, params=get_args, headers=headers).json()
 
 # Reference: https://developer.spotify.com/documentation/web-api/reference/#endpoint-search

--- a/backend/spotify_facade.py
+++ b/backend/spotify_facade.py
@@ -12,7 +12,7 @@ class Constants(Enum):
 
 spotify_api = Blueprint('spotify_api', __name__)
 
-# Reference: 
+# Reference: https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-recommendations
 def get_tracks(mood, authorization, **kwargs):
 	get_args = {}
 	if 'limit' not in kwargs:

--- a/backend/spotify_facade.py
+++ b/backend/spotify_facade.py
@@ -57,7 +57,7 @@ def get_playlist_from_mood(mood_name, **kwargs):
 
 		if 'seed_artists' not in get_args:
 			get_args['seed_artists'] = seed_artists
-		if 'seed_genres' not in get_args
+		if 'seed_genres' not in get_args:
 			get_args['top_genres'] = list(top_genres)
 
 	if 'seed_tracks' not in get_args:

--- a/backend/spotify_facade.py
+++ b/backend/spotify_facade.py
@@ -24,6 +24,7 @@ def get_playlist_from_mood(mood_name, **kwargs):
 	mood = generator.generate()
 	if mood is None:
 		return Response(status = 404)
+	mood = mood.params
 
 	get_args = {}
 	if 'limit' not in kwargs:

--- a/backend/spotify_facade.py
+++ b/backend/spotify_facade.py
@@ -1,6 +1,6 @@
 import requests
 from enum import Enum
-from flask import Blueprint, g
+from flask import Blueprint, g, request
 from .auth import extract_credentials
 from .mood_generator import MoodGenerator, CreateOrUpdateMoodStrategy, \
 		GetMoodFromDBStrategy, DeleteMoodFromDBStrategy
@@ -28,9 +28,9 @@ def get_playlist_from_mood(mood_name, **kwargs):
 
 	get_args = {}
 	if 'limit' not in kwargs:
-		get_args['limit'] = Constants.LIMIT
+		get_args['limit'] = Constants.LIMIT.value
 	if 'market' not in kwargs:
-		get_args['market'] = Constants.MARKET
+		get_args['market'] = Constants.MARKET.value
 	for k, v in mood.items():
 		# separate Spotify parameters
 		if 'seed' not in k:
@@ -45,7 +45,7 @@ def get_playlist_from_mood(mood_name, **kwargs):
 
 	if 'seed_artists' not in get_args or 'seed_genres' not in get_args:
 		# Reference: https://developer.spotify.com/console/get-current-user-top-artists-and-tracks/
-		top_artists = requests.get(Constants.SPOTIFY_TOP_ARTISTS_AND_TRACKS.format('artists'), params={'limit': Constants.LIMIT}, headers=headers)
+		top_artists = requests.get(Constants.SPOTIFY_TOP_ARTISTS_AND_TRACKS.value.format('artists'), params={'limit': Constants.LIMIT.value}, headers=headers)
 		if not top_artists.ok:
 			print(top_artists.text)
 			abort(500, "Error in retrieving user's top artists")
@@ -63,7 +63,7 @@ def get_playlist_from_mood(mood_name, **kwargs):
 
 	if 'seed_tracks' not in get_args:
 		# Reference: https://developer.spotify.com/console/get-current-user-top-artists-and-tracks/
-		top_tracks = requests.get(Constants.SPOTIFY_TOP_ARTISTS_AND_TRACKS.format('tracks'), params={'limit': Constants.LIMIT}, headers=headers)
+		top_tracks = requests.get(Constants.SPOTIFY_TOP_ARTISTS_AND_TRACKS.value.format('tracks'), params={'limit': Constants.LIMIT.value}, headers=headers)
 		if not top_tracks.ok:
 			print(top_tracks.text)
 			abort(500, "Error in retrieving user's top tracks")
@@ -72,7 +72,7 @@ def get_playlist_from_mood(mood_name, **kwargs):
 		for track in top_tracks['items']:
 			get_args['seed_tracks'].append(track['id'])
 
-	return requests.get(Constants.SPOTIFY_RECOMMENDATIONS, params=get_args, headers=headers).json()
+	return requests.get(Constants.SPOTIFY_RECOMMENDATIONS.value, params=get_args, headers=headers).json()
 
 # Reference: https://developer.spotify.com/documentation/web-api/reference/#endpoint-search
 @spotify_api.route("/search", methods=['GET'])
@@ -83,20 +83,20 @@ def get_spotify_id():
 	if request.args.get('query') is None: # ?query = query string
 		abort(422, description="Unprocessable entity: missing query")
 
-	if request.args.get('type') is None: # ?type = query string (artist, genre, or track)
+	if request.args.get('type') is None: # ?type = query string (artist or track)
 		abort(422, description="Unprocessable entity: missing query type")
 
 	get_args = {}
 	if 'limit' not in request.args:
-		get_args['limit'] = Constants.LIMIT
+		get_args['limit'] = Constants.LIMIT.value
 	if 'market' not in request.args:
-		get_args['market'] = Constants.MARKET
+		get_args['market'] = Constants.MARKET.value
 	if 'offset' not in request.args:
-		get_args['offset'] = Constants.OFFSET
+		get_args['offset'] = Constants.OFFSET.value
 	for k, v in request.args.items():
 		get_args[k] = v
 
 	oauth_access_token = g.access_token
 	headers = {'Accept': 'application/json', 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + oauth_access_token}
 
-	return requests.get(Constants.SPOTIFY_SEARCH, params=get_args, headers=headers).json()
+	return requests.get(Constants.SPOTIFY_SEARCH.value, params=get_args, headers=headers).json()

--- a/backend/spotify_facade.py
+++ b/backend/spotify_facade.py
@@ -18,7 +18,7 @@ spotify_api = Blueprint('spotify_api', __name__)
 spotify_api.before_request(extract_credentials)
 
 # Reference: https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-recommendations
-@mood_api.route("/playlist-from-mood", methods=['GET'])
+@spotify_api.route("/playlist-from-mood", methods=['GET'])
 def get_playlist_from_mood(mood_name, **kwargs):
 	generator = MoodGenerator(mood_name, g.user_id, None, GetMoodFromDBStrategy)
 	mood = generator.generate()

--- a/backend/tests/test_mood.py
+++ b/backend/tests/test_mood.py
@@ -5,7 +5,7 @@ def test_hello_world():
     resp = requests.get("http://localhost:8000/")
     assert(resp.text == "Hello World!")
 
-def do_no_test_mood_api():
+def do_not_test_mood_api():
     url = 'http://localhost:8000/api/v1/mood/fakeUser/mood?name=helloworld'
     data = {
         "seed_artists": ["hello", "world", "python"],

--- a/backend/tests/test_spotify_facade.py
+++ b/backend/tests/test_spotify_facade.py
@@ -1,0 +1,22 @@
+import requests
+import json
+
+def do_not_int_test_spotify_api():
+    mood_url = 'http://localhost:8000/api/v1/mood/mood?name=testrecommendations'
+    spotify_playlist_url = 'http://localhost:8000/api/v1/spotify/playlist-from-mood?mood_name=testrecommendations'
+
+    data = {
+        "danceability": ["0.12", "0.37", "0.18"],
+        "valence": ["0.12", "0.37", "0.18"]
+    }
+    resp = requests.put(mood_url, data=json.dumps(data))
+    json_resp = resp.json()
+    assert("danceability" in json_resp)
+
+    resp = requests.put(spotify_playlist_url, data=json.dumps(data))
+    json_resp = resp.json()
+    assert("tracks" in json_resp)
+
+    resp = requests.delete(url)
+
+

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ from flask_cors import CORS
 from os import environ
 from backend.mood import mood_api
 from backend.auth import auth_api
+from backend.spotify_facade import spotify_api
 from backend.utils.db import DB
 
 with DB() as db:

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ from backend.mood import mood_api
 
 app = Flask(__name__)
 app.register_blueprint(mood_api, url_prefix='/api/v1/mood')
+app.register_blueprint(spotify_api, url_prefix='/api/v1/spotify')
 
 @app.route("/")
 def hello():


### PR DESCRIPTION
Closes #26 

Spotify facade, which provides high-level functionality for interfacing with the Spotify API, like generating a playlist from a mood and searching for the IDs of artists and tracks, is now implemented and tested. While integration tests are not currently working, I have thoroughly tested the integration of the Mood API and Spotify facade (via the DB) using Postman. The tests I ran are available in backend/tests/test_spotify_facade.py.

Spotify facade currently contains two features:
1) generating a playlist from a mood: This feature only requires the name of the mood, and it interfaces with the DB to obtain the mood params, makes calls to the Spotify API to use the user's top artists, tracks, and genres as seeds for the recommendation call, and finally makes a call to Spotify's recommendation service. Currently, the playlist is not generated; only a list of tracks is returned. TODO: officially make the playlist in playlist.py.

2) searching for the IDs of artists and tracks: This feature allows the client to search for the Spotify IDs of artists and tracks that match a query.