### PR TITLE
Use Mood ID while creating playlists

### DIFF
--- a/backend/mood.py
+++ b/backend/mood.py
@@ -23,13 +23,13 @@ def create_update_custom_mood():
 	# Request body validation
 	# Reference: https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-recommendations
 	data = request.data.decode("utf8")
-	generator = MoodGenerator(name, g.user_id, data, CreateOrUpdateMoodStrategy)
+	generator = MoodGenerator(name, g.user_id, data, None, CreateOrUpdateMoodStrategy)
 	try:
 		mood = generator.generate()
 	except exceptions.ValidationError as err:
 		abort(422, description="Unprocessable entity: " + str(err.messages))
 
-	data = mood.params
+	data = {**mood.params, 'mood_id':mood.mood_id}
 
 	print(data)
 	return jsonify(data)
@@ -44,11 +44,12 @@ def delete_custom_mood():
 	if name is None:
 		abort(422, description="Unprocessable entity: missing mood name query string")
 
-	generator = MoodGenerator(name, g.user_id, None, DeleteMoodFromDBStrategy)
+	generator = MoodGenerator(name, g.user_id, None, None, DeleteMoodFromDBStrategy)
 	mood = generator.generate()
 
 	if not mood is None:
-		return jsonify(mood.params)
+		data = {**mood.params, 'mood_id': mood.mood_id}
+		return jsonify(data)
 	return Response(status = 200)
 
 # Read mood (GET request)
@@ -61,9 +62,10 @@ def get_custom_mood():
 	if name is None:
 		abort(422, description="Unprocessable entity: missing mood name query string")
 
-	generator = MoodGenerator(name, g.user_id, None, GetMoodFromDBStrategy)
+	generator = MoodGenerator(name, g.user_id, None, None, GetMoodFromDBStrategy)
 	mood = generator.generate()
 
 	if not mood is None:
-		return jsonify(mood.params)
+		data = {**mood.params, 'mood_id': mood.mood_id}
+		return jsonify(data)
 	return Response(status = 404)

--- a/backend/mood_generator.py
+++ b/backend/mood_generator.py
@@ -25,24 +25,26 @@ class Mood:
     
 
 class MoodGenerator:
-    def __init__(self, name, creator_id, params, strategy):
+    def __init__(self, name, creator_id, params, mood_id, strategy):
         self.name = name
         self.creator_id = creator_id
         self.params = params
         self.strategy = strategy
+        self.mood_id = mood_id
 
     def set_strategy(self, strategy):
         self.strategy = strategy
 
     def generate(self):
-        return self.strategy(self.name, self.creator_id, self.params).generate()
+        return self.strategy(self.name, self.creator_id, self.params, self.mood_id).generate()
 
 
 class GenerationStrategy:
-    def __init__(self, name, creator_id, params):
+    def __init__(self, name, creator_id, params, mood_id):
         self.name = name
         self.creator_id = creator_id
         self.params = params
+        self.mood_id = mood_id
     
     def generate(self):
         raise NotImplementedError
@@ -82,3 +84,12 @@ class DeleteMoodFromDBStrategy(GenerationStrategy):
         if mood_id is None:
             return None
         return Mood(self.name, self.creator_id, params, mood_id)
+
+class GetMoodFromDBWithIDStrategy(GenerationStrategy):
+    def generate(self):
+        mood_name, creator_id, params = None, None, None
+        with DB() as db:
+            mood_name, creator_id, params = db.get_mood_by_id(self.mood_id)
+        if mood_name is None:
+            return None
+        return Mood(mood_name, creator_id, params, self.mood_id)

--- a/backend/playlist.py
+++ b/backend/playlist.py
@@ -14,7 +14,7 @@ class Constants(Enum):
 
 @playlist_api.route("/playlist-from-mood", methods=['GET'])
 def get_playlist_from_mood():
-	# request.args should contain mood_name and idx (i.e. playlist idx)
+	# request.args should contain mood_id, mood_name and idx (i.e. playlist idx)
 	resp = requests.get(Constants.GET_PLAYLIST_FROM_MOOD.value, params=request.args, headers=request.headers)
 	if not resp.ok:
 		return resp.json()
@@ -24,9 +24,12 @@ def get_playlist_from_mood():
 	for track in resp_json['tracks']:
 		track_uris.append(track['uri'])
 
-	# mood_name already handled by get_playlist_by_mood
+	# mood_id already handled by get_playlist_by_mood
 	if 'idx' not in request.args:
 		abort(422, description="Unprocessable entity: missing playlist idx")
+
+	if 'mood_name' not in request.args:
+		abort(422, description="Unprocessable entity: missing mood name")
 
 	headers = {'Accept': 'application/json', 'Content-Type': 'application/json', 'Authorization': request.headers['Authorization']}
 	resp = requests.post(Constants.MAKE_PLAYLIST.value, json={'playlist_name': request.args['mood_name'] + ' ' + request.args['idx'], \

--- a/backend/spotify_facade.py
+++ b/backend/spotify_facade.py
@@ -2,8 +2,7 @@ import requests
 from enum import Enum
 from flask import Blueprint, request, abort, jsonify, Response, g
 from .auth import extract_credentials
-from .mood_generator import MoodGenerator, CreateOrUpdateMoodStrategy, \
-                GetMoodFromDBStrategy, DeleteMoodFromDBStrategy
+from .mood_generator import MoodGenerator, GetMoodFromDBWithIDStrategy
 import json
 class Constants(Enum):
     LIMIT = '10'
@@ -110,10 +109,17 @@ def get_playlist_from_mood():
     if not request.args:
         abort(400, description="Malformed syntax")
 
-    if request.args.get('mood_name') is None: # ?mood_name = mood name string
-        abort(422, description="Unprocessable entity: missing mood name")
+    if request.args.get('mood_id') is None: # ?mood_id = mood id string
+        abort(422, description="Unprocessable entity: missing mood id")
 
-    generator = MoodGenerator(request.args.get('mood_name'), g.user_id, None, GetMoodFromDBStrategy)
+    mood_id = request.args.get('mood_id')
+
+    try:
+        mood_id = int(mood_id)
+    except:
+        abort(422, description="Unprocessable entity: invalid mood id")
+
+    generator = MoodGenerator(None, None, None, mood_id, GetMoodFromDBWithIDStrategy)
     mood = generator.generate()
     if mood is None:
         return Response(status = 404)

--- a/backend/utils/db.py
+++ b/backend/utils/db.py
@@ -34,7 +34,6 @@ class DB:
                 "name, creator_id, params"
                 ") values (%s, %s, %s) RETURNING mood_id;" 
                 )
-        params = Json(params)
         self._cursor.execute(insert, (name, creator_id, params)) 
         return self._cursor.fetchone()[0]
 
@@ -60,7 +59,7 @@ class DB:
         select = (
                 "SELECT * FROM Moods WHERE mood_id = %s;"
                 )
-        self._cursor.execute(select, (mood_id))
+        self._cursor.execute(select, (mood_id,))
         row = self._cursor.fetchone()
         if row is None:
             return None, None, None

--- a/backend/utils/db.py
+++ b/backend/utils/db.py
@@ -56,6 +56,16 @@ class DB:
             return None, None
         return row[0], row[3]
 
+    def get_mood_by_id(self, mood_id):
+        select = (
+                "SELECT * FROM Moods WHERE mood_id = %s;"
+                )
+        self._cursor.execute(select, (mood_id))
+        row = self._cursor.fetchone()
+        if row is None:
+            return None, None, None
+        return row[1], row[2], row[3]
+
     def delete_mood(self, name, creator_id):
         delete = (
                 "DELETE FROM Moods WHERE name = %s AND creator_id = %s RETURNING *;"


### PR DESCRIPTION
- Send back mood ID of a created/updated mood along with other information
- Use mood id to create playlist
    - This is necessary as when we allow users to copy moods created by others, the DB entry for a mood doesn't change
    - So, need a way to reference a mood that does not involve the creator ID, as creator ID may not be the user ID for the mood
- Please note changes in API
    - Mood Creation/Update: mood_id is returned along with other information
    - Playlist Creation based on mood: Must specify (along with mood name and idx) the mood_id too