### PR TITLE
Fe/home page requests

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -4,36 +4,93 @@ const axios = require("axios");
 
 // This file handles all API calls and exports simple functions for accessing backend data.
 
-export async function requestNewPlaylist() {
-  // TODO: Request a new playlist for this user and a given mood.
-  return { name: "Brand new playlist!", id: 505050 };
-}
+var baseURL = "https://musaic-13018.herokuapp.com/api/v1";
 
-export async function fetchHomePageData(jwt) {
-  // Fetch any moods and playlists from the backend.
+export async function requestNewPlaylist(jwt, moodID, moodName) {
+  // Request a new playlist for this user and a given mood.
   const data = {
     error: "",
-    data: null,
+    playlist: null,
   };
   try {
-    const response = await axios.get(
-      "https://musaic-13018.herokuapp.com/api/v1/user/moods",
+    let response = await axios.get(
+      `${baseURL}/playlist/playlist-from-mood?mood_id=${moodID}&mood_name=${moodName}`,
       { headers: { Authorization: `Bearer ${jwt}` } }
     );
-    // console.log(response.status)
-    // console.log(response.data)
+    // console.log(response);
+    if (response.data.error) {
+      throw response.data.error;
+    } else if (response.status != 200) {
+      throw response.statusText;
+    } else if (response.data.mood_id && response.data.mood_id != moodID) {
+      throw "Wrong mood id returned";
+    }
+    data.playlist = response.data;
+  } catch (error) {
+    // console.log(error);
+    data.error = error;
+  }
+  return data;
+}
+
+// Fetch playlists associated with a given mood.
+export async function fetchPlaylistsFromMood(jwt, moodID) {
+  const data = {
+    error: "",
+    playlists: null,
+  };
+  try {
+    let response = await axios.get(
+      `${baseURL}/playlist/playlists?mood_id=${moodID}`,
+      { headers: { Authorization: `Bearer ${jwt}` } }
+    );
+    if (response.data.error) {
+      throw response.data.error;
+    } else if (response.status != 200) {
+      throw response.statusText;
+    } else if (response.data.mood_id && response.data.mood_id != moodID) {
+      throw "Wrong mood ID returned";
+    }
+    data.playlists = response.data;
+  } catch (error) {
+    data.error = error;
+  }
+  return data;
+}
+
+// Fetch any moods belonging to this user from the backend.
+export async function fetchUserMoods(jwt) {
+  const data = {
+    error: "",
+    moods: null,
+  };
+  // Request all moods belonging to this user.
+  try {
+    const response = await axios.get(`${baseURL}/user/moods`, {
+      headers: { Authorization: `Bearer ${jwt}` },
+    });
+    // console.log("response.data" + JSON.stringify(response.data))
     if (response.data.error) {
       throw response.data.error;
     } else if (response.status != 200) {
       throw response.statusText;
     }
-    data.data = response.data;
-  } catch (error) {
-    data.error = error;
-    return data;
-  }
 
-  // TODO: Fetch playlists and add to result.
+    data.moods = response.data.created_moods;
+    // Combine created_moods and external_moods, avoiding duplicates.
+    response.data.external_moods.forEach((e_mood) => {
+      if (
+        !response.data.created_moods.some(
+          (c_mood) => c_mood.mood_id === e_mood.mood_id
+        )
+      ) {
+        data.moods.push(e_mood);
+      }
+    });
+  } catch (error) {
+    // console.log(error)
+    data.error = error;
+  }
   return data;
 }
 
@@ -49,7 +106,7 @@ export async function submitQuestionnaire(moodName, responses) {
   };
   try {
     const response = await axios.put(
-      `https://musaic-13018.herokuapp.com/api/v1/mood/mood?name=${moodName}`,
+      `${baseURL}/mood/mood?name=${moodName}`,
       responses,
       { headers: { Authorization: `Bearer ${cookies.jwt}` } }
     );

--- a/pages/questionnaire.js
+++ b/pages/questionnaire.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useRouter } from "next/router";
 import Questionnaire from "../views/questionnaire";
 import { submitQuestionnaire } from "../lib/fetch";
@@ -14,15 +14,19 @@ const QuestionnaireController = (props) => {
 
     try {
       const response = await submitQuestionnaire(moodName, paramResponses);
-      // console.log("submission response: " + JSON.stringify(response));
       if (response.error !== "") {
         throw response.error;
       }
     } catch (err) {
       console.log(err);
-      setError(
-        "Sorry, we couldn't submit your responses. Please try again later."
-      );
+      if (err === "Access Token expired") {
+        setError("Your session has expired. Please log in again.");
+      } else {
+        setError(
+          "Sorry, we couldn't submit your responses. Please try again later."
+        );
+      }
+
       return;
     }
 
@@ -32,12 +36,11 @@ const QuestionnaireController = (props) => {
   const defaultSettings = {
     // attribute: [min, max, target]
     name: "moodName",
-    danceability: [0.3, 0.7, 0.5],
-    instrumentalness: [0.3, 0.7, 0.5],
-    popularity: [0.3, 0.7, 0.5],
-    speechiness: [0.3, 0.7, 0.5],
-    valence: [0.3, 0.7, 0.5],
-    energy: [0.3, 0.7, 0.5],
+    danceability: [0.0, 1.0, 0.5],
+    instrumentalness: [0.0, 1.0, 0.5],
+    speechiness: [0.0, 1.0, 0.5],
+    valence: [0.0, 1.0, 0.5],
+    energy: [0.0, 1.0, 0.5],
   };
 
   return (

--- a/views/home.js
+++ b/views/home.js
@@ -31,12 +31,16 @@ const Home = (props) => {
   });
 
   const makeNewPlaylist = async (moodId) => {
-    let newPlaylist = await props.getNewPlaylist(moodId);
+    let moodName = moods.get(moodId).name;
+    let newPlaylist = await props.getNewPlaylist(moodId, moodName);
+    if (newPlaylist.id === null) {
+      return;
+    }
     setMoods((oldState) => {
       let playlists = cloneDeep(moods.get(moodId).playlists);
       playlists.push(newPlaylist);
       return new Map(oldState).set(moodId, {
-        name: moods.get(moodId).name,
+        name: moodName,
         playlists: playlists,
       });
     });
@@ -55,7 +59,7 @@ const Home = (props) => {
             <div className={styles.list}>
               {moods.get(openMood).playlists.map((playlist) => (
                 <PlaylistListItem
-                  key={playlist.id}
+                  key={playlist.idx}
                   name={playlist.name}
                   id={playlist.id}
                 />

--- a/views/playlist.js
+++ b/views/playlist.js
@@ -1,16 +1,32 @@
 import React from "react";
 import PageHead from "../components/head";
 import styles from "../styles/playlist.module.css";
+import { useRouter } from "next/router";
 
+const Playlist = () => {
+  const router = useRouter();
+  const { playlist } = router.query;
 
-const Playlist = (props) => {
-  return (<>
-    <PageHead/>
-    <div className={`${styles.playlistContainer}`}>
-      <div className={`${styles.embed} ${styles.playlistText}`}><p>Here's your custom playlist!</p></div>
-      <div className={`${styles.embed}`}><iframe src="https://open.spotify.com/embed/album/1DFixLWuPkv3KT3TnV35m3" width="300" height="380" frameBorder="0" allowtransparency="true" allow="encrypted-media"></iframe></div>
-    </div>
-  </>);
+  return (
+    <>
+      <PageHead />
+      <div className={`${styles.playlistContainer}`}>
+        <div className={`${styles.embed} ${styles.playlistText}`}>
+          <p>Here's your custom playlist!</p>
+        </div>
+        <div className={`${styles.embed}`}>
+          <iframe
+            src={`https://open.spotify.com/embed/playlist/${playlist}`}
+            width="300"
+            height="380"
+            frameBorder="0"
+            allowtransparency="true"
+            allow="encrypted-media"
+          ></iframe>
+        </div>
+      </div>
+    </>
+  );
 };
-  
+
 export default Playlist;

--- a/views/questionnaire.js
+++ b/views/questionnaire.js
@@ -7,18 +7,9 @@ const Questionnaire = (props) => {
   const [responses, setResponses] = useState(props.defaultSettings);
 
   const handleChange = (e) => {
-    var min = parseFloat((parseFloat(e.target.value) - 0.2).toFixed(2));
-    if (min < 0.0) {
-      min = 0.0;
-    }
-    var max = parseFloat((parseFloat(e.target.value) + 0.2).toFixed(2));
-    if (max > 1.0) {
-      max = 1.0;
-    }
-
     setResponses((prevResponses) => ({
       ...prevResponses,
-      [e.target.id]: [min, max, parseFloat(e.target.value)],
+      [e.target.id]: [0.0, 1.0, parseFloat(e.target.value)],
     }));
   };
 
@@ -73,18 +64,6 @@ const Questionnaire = (props) => {
             <Form.Label className={styles.formText}>
               Instrumentalness
             </Form.Label>
-            <Form.Control
-              type="range"
-              className="form-range"
-              min="0.0"
-              max="1.0"
-              step="0.01"
-              defaultValue="0.5"
-              onChange={(e) => handleChange(e)}
-            />
-          </Form.Group>
-          <Form.Group controlId="popularity">
-            <Form.Label className={styles.formText}>Popularity</Form.Label>
             <Form.Control
               type="range"
               className="form-range"


### PR DESCRIPTION
In this commit:
* Requests to load playlists on the home page
* Requests to create new playlists from a mood on the home page
* Better error messages for the user, including a prompt to log in again if your Spotify token expires
* Fixes for mood creation based on Spotify recommendation tests - set min and max value for each parameter to 0 and 1, remove popularity as a parameter because Spotify doesn't accept it
* Display playlists with the same name they have on Spotify ([mood name] [number])
* Display user's created moods and external moods together in moods list
* Parameterize playlist display page so it can display any playlist

The core functionality of creating and displaying moods and playlists should now be finished on the frontend.