### PR TITLE
Add unit tests for home page and fetch.js

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["next/babel"]
+}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.com/cs130-w21/18.svg?branch=fe%2Fmaster)](https://travis-ci.com/cs130-w21/18)
+
 This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
 
 ## Getting Started for Developers
@@ -25,5 +27,7 @@ To learn more about Next.js, take a look at the following resources:
 Musaic is automatically deployed to https://test-fe-130.herokuapp.com every time a commit is pushed to the branch fe/master that builds
 successfully and passes our automated tests. Any push to GitHub will trigger the Travis CI script, found in .travis.yml, which builds the production version of the app and runs all Jest tests.
 
-To manually trigger a build of the production version, you can use `npm run build`. To manually run the tests, use
+To manually trigger a build of the production version locally, you can use `npm run build`. To manually run the tests, use
 `npm run test`.
+
+You can manually trigger a build of the production frontend app and run our unit tests by visiting https://travis-ci.com/github/cs130-w21/18, selecting the most recent build of the branch fe/master, and clicking "Restart build."

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
 
-## Getting Started
+## Getting Started for Developers
 
-First, run the development server:
+To run the app locally, first make sure Node.js and npm are installed. Run `npm install` to install all the dependencies.
+Then run the development server:
 
 ```bash
 npm run dev
@@ -10,17 +11,19 @@ npm run dev
 yarn dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the result. Pages auto-update as you edit the files.
 
-You can start editing the page by modifying `pages/index.js`. The page auto-updates as you edit the file.
-
-[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.js`.
-
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
-
-## Learn More
+## About Next.js
 
 To learn more about Next.js, take a look at the following resources:
 
 - [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
 - [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+
+## CI/CD
+
+Musaic is automatically deployed to https://test-fe-130.herokuapp.com every time a commit is pushed to the branch fe/master that builds
+successfully and passes our automated tests. Any push to GitHub will trigger the Travis CI script, found in .travis.yml, which builds the production version of the app and runs all Jest tests.
+
+To manually trigger a build of the production version, you can use `npm run build`. To manually run the tests, use
+`npm run test`.

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,7 +17,11 @@ module.exports = {
   clearMocks: true,
 
   // Indicates whether the coverage information should be collected while executing the test
-  // collectCoverage: false,
+  collectCoverageFrom: [
+    "**/*.{js,jsx,ts,tsx}",
+    "!**/*.d.ts",
+    "!**/node_modules/**",
+  ],
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
   // collectCoverageFrom: undefined,
@@ -81,7 +85,9 @@ module.exports = {
   // ],
 
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-  // moduleNameMapper: {},
+  moduleNameMapper: {
+    "^.+\\.module\\.(css|sass|scss)$": "identity-obj-proxy",
+  },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
   // modulePathIgnorePatterns: [],
@@ -128,7 +134,7 @@ module.exports = {
   // setupFiles: [],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
-  // setupFilesAfterEnv: [],
+  setupFilesAfterEnv: ["./jest.setup.js"],
 
   // The number of seconds after which a test is considered as slow and reported as such in the results.
   // slowTestThreshold: 5,
@@ -170,13 +176,16 @@ module.exports = {
   // timers: "real",
 
   // A map from regular expressions to paths to transformers
-  // transform: undefined,
+  transform: {
+    "^.+\\.(js|jsx|ts|tsx)$": "<rootDir>/node_modules/babel-jest",
+    "^.+\\.css$": "<rootDir>/jest.cssTransform.js",
+  },
 
   // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
-  // transformIgnorePatterns: [
-  //   "\\\\node_modules\\\\",
-  //   "\\.pnp\\.[^\\\\]+$"
-  // ],
+  transformIgnorePatterns: [
+    "/node_modules/",
+    "^.+\\.module\\.(css|sass|scss)$",
+  ],
 
   // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
   // unmockedModulePathPatterns: undefined,

--- a/jest.cssTransform.js
+++ b/jest.cssTransform.js
@@ -1,0 +1,8 @@
+module.exports = {
+  process() {
+    return "module.exports = {};";
+  },
+  getCacheKey() {
+    return "cssTransform";
+  },
+};

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/extend-expect";

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -1,5 +1,3 @@
-import { parseCookies } from "nookies";
-
 const axios = require("axios");
 
 // This file handles all API calls and exports simple functions for accessing backend data.
@@ -113,13 +111,12 @@ export async function fetchUserMoods(jwt) {
 
 /**
  * This function puts user information from the questionnaire to the backend
+ * @param {String} jwt - JSON Web Token
  * @param {String} moodName - a mood's name
  * @param {Object} responses - user's responses from the questionnaire excluding moodName
  */
-export async function submitQuestionnaire(moodName, responses) {
+export async function submitQuestionnaire(jwt, moodName, responses) {
   // Make PUT request to send questionnaire responses to the backend
-  const cookies = parseCookies();
-  // console.log("cookies: " + JSON.stringify(cookies))
   // console.log("submitting these responses: " + JSON.stringify(responses))
 
   const data = {
@@ -130,7 +127,7 @@ export async function submitQuestionnaire(moodName, responses) {
     const response = await axios.put(
       `${baseURL}/mood/mood?name=${moodName}`,
       responses,
-      { headers: { Authorization: `Bearer ${cookies.jwt}` } }
+      { headers: { Authorization: `Bearer ${jwt}` } }
     );
     // console.log(response.status)
     // console.log(response.data)

--- a/package-lock.json
+++ b/package-lock.json
@@ -185,51 +185,6 @@
         }
       }
     },
-    "@babel/helper-annotate-as-pure": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.13.tgz",
-      "integrity": "sha512-7YXfX5wQ5aYM/BOlbSccHDbuXXFPxeoUmfWtz8le2yTkTZc+BxsiEnENFoi2SlmA8ewDkG2LgIMIVzzn2h8kfw==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.12.13"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
-          "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
-      }
-    },
-    "@babel/helper-builder-binary-assignment-operator-visitor": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.12.13.tgz",
-      "integrity": "sha512-CZOv9tGphhDRlVjVkAgm8Nhklm9RzSmWpX2my+t7Ua/KT616pEzXsQCjinzvkRvHWJ9itO4f296efroX23XCMA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-explode-assignable-expression": "^7.12.13",
-        "@babel/types": "^7.12.13"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
-          "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
-      }
-    },
     "@babel/helper-compilation-targets": {
       "version": "7.13.8",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.8.tgz",
@@ -240,67 +195,6 @@
         "@babel/helper-validator-option": "^7.12.17",
         "browserslist": "^4.14.5",
         "semver": "^6.3.0"
-      }
-    },
-    "@babel/helper-create-class-features-plugin": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.13.8.tgz",
-      "integrity": "sha512-qioaRrKHQbn4hkRKDHbnuQ6kAxmmOF+kzKGnIfxPK4j2rckSJCpKzr/SSTlohSCiE3uAQpNDJ9FIh4baeE8W+w==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-function-name": "^7.12.13",
-        "@babel/helper-member-expression-to-functions": "^7.13.0",
-        "@babel/helper-optimise-call-expression": "^7.12.13",
-        "@babel/helper-replace-supers": "^7.13.0",
-        "@babel/helper-split-export-declaration": "^7.12.13"
-      }
-    },
-    "@babel/helper-create-regexp-features-plugin": {
-      "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.17.tgz",
-      "integrity": "sha512-p2VGmBu9oefLZ2nQpgnEnG0ZlRPvL8gAGvPUMQwUdaE8k49rOMuZpOwdQoy5qJf6K8jL3bcAMhVUlHAjIgJHUg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-annotate-as-pure": "^7.12.13",
-        "regexpu-core": "^4.7.1"
-      }
-    },
-    "@babel/helper-define-polyfill-provider": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.1.4.tgz",
-      "integrity": "sha512-K5V2GaQZ1gpB+FTXM4AFVG2p1zzhm67n9wrQCJYNzvuLzQybhJyftW7qeDd2uUxPDNdl5Rkon1rOAeUeNDZ28Q==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-compilation-targets": "^7.13.0",
-        "@babel/helper-module-imports": "^7.12.13",
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/traverse": "^7.13.0",
-        "debug": "^4.1.1",
-        "lodash.debounce": "^4.0.8",
-        "resolve": "^1.14.2",
-        "semver": "^6.1.2"
-      }
-    },
-    "@babel/helper-explode-assignable-expression": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.13.0.tgz",
-      "integrity": "sha512-qS0peLTDP8kOisG1blKbaoBg/o9OSa1qoumMjTK5pM+KDTtpxpsiubnCGP34vK8BXGcb2M9eigwgvoJryrzwWA==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.13.0"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
-          "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-function-name": {
@@ -334,29 +228,6 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.12.13"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
-          "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
-      }
-    },
-    "@babel/helper-hoist-variables": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.13.0.tgz",
-      "integrity": "sha512-0kBzvXiIKfsCA0y6cFEIJf4OdzfpRuNk4+YTeHZpGGc666SATFKTz6sRncwFnQk7/ugJ4dSrCj6iJuvW4Qwr2g==",
-      "dev": true,
-      "requires": {
-        "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.0"
       },
       "dependencies": {
         "@babel/types": {
@@ -474,30 +345,6 @@
       "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
       "dev": true
     },
-    "@babel/helper-remap-async-to-generator": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.13.0.tgz",
-      "integrity": "sha512-pUQpFBE9JvC9lrQbpX0TmeNIy5s7GnZjna2lhhcHC7DzgBs6fWn722Y5cfwgrtrqc7NAJwMvOa0mKhq6XaE4jg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-annotate-as-pure": "^7.12.13",
-        "@babel/helper-wrap-function": "^7.13.0",
-        "@babel/types": "^7.13.0"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
-          "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
-      }
-    },
     "@babel/helper-replace-supers": {
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.0.tgz",
@@ -530,28 +377,6 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.12.13"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
-          "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
-      }
-    },
-    "@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.12.1.tgz",
-      "integrity": "sha512-Mf5AUuhG1/OCChOJ/HcADmvcHM42WJockombn8ATJG3OnyiSxBK/Mm5x78BQWvmtXZKHgbjdGL2kin/HOLlZGA==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.12.1"
       },
       "dependencies": {
         "@babel/types": {
@@ -600,31 +425,6 @@
       "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
       "dev": true
     },
-    "@babel/helper-wrap-function": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.13.0.tgz",
-      "integrity": "sha512-1UX9F7K3BS42fI6qd2A4BjKzgGjToscyZTdp1DjknHLCIvpgne6918io+aL5LXFcER/8QWiwpoY902pVEqgTXA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-function-name": "^7.12.13",
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.0"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
-          "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
-      }
-    },
     "@babel/helpers": {
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.0.tgz",
@@ -664,141 +464,6 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.4.tgz",
       "integrity": "sha512-uvoOulWHhI+0+1f9L4BoozY7U5cIkZ9PgJqvb041d6vypgUmtVPG4vmGm4pSggjl8BELzvHyUeJSUyEMY6b+qA=="
     },
-    "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.13.8.tgz",
-      "integrity": "sha512-rPBnhj+WgoSmgq+4gQUtXx/vOcU+UYtjy1AA/aeD61Hwj410fwYyqfUcRP3lR8ucgliVJL/G7sXcNUecC75IXA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/helper-remap-async-to-generator": "^7.13.0",
-        "@babel/plugin-syntax-async-generators": "^7.8.4"
-      }
-    },
-    "@babel/plugin-proposal-class-properties": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.13.0.tgz",
-      "integrity": "sha512-KnTDjFNC1g+45ka0myZNvSBFLhNCLN+GeGYLDEA8Oq7MZ6yMgfLoIRh86GRT0FjtJhZw8JyUskP9uvj5pHM9Zg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.13.0",
-        "@babel/helper-plugin-utils": "^7.13.0"
-      }
-    },
-    "@babel/plugin-proposal-dynamic-import": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.13.8.tgz",
-      "integrity": "sha512-ONWKj0H6+wIRCkZi9zSbZtE/r73uOhMVHh256ys0UzfM7I3d4n+spZNWjOnJv2gzopumP2Wxi186vI8N0Y2JyQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3"
-      }
-    },
-    "@babel/plugin-proposal-export-namespace-from": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.12.13.tgz",
-      "integrity": "sha512-INAgtFo4OnLN3Y/j0VwAgw3HDXcDtX+C/erMvWzuV9v71r7urb6iyMXu7eM9IgLr1ElLlOkaHjJ0SbCmdOQ3Iw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13",
-        "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
-      }
-    },
-    "@babel/plugin-proposal-json-strings": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.13.8.tgz",
-      "integrity": "sha512-w4zOPKUFPX1mgvTmL/fcEqy34hrQ1CRcGxdphBc6snDnnqJ47EZDIyop6IwXzAC8G916hsIuXB2ZMBCExC5k7Q==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/plugin-syntax-json-strings": "^7.8.3"
-      }
-    },
-    "@babel/plugin-proposal-logical-assignment-operators": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.13.8.tgz",
-      "integrity": "sha512-aul6znYB4N4HGweImqKn59Su9RS8lbUIqxtXTOcAGtNIDczoEFv+l1EhmX8rUBp3G1jMjKJm8m0jXVp63ZpS4A==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
-      }
-    },
-    "@babel/plugin-proposal-nullish-coalescing-operator": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.13.8.tgz",
-      "integrity": "sha512-iePlDPBn//UhxExyS9KyeYU7RM9WScAG+D3Hhno0PLJebAEpDZMocbDe64eqynhNAnwz/vZoL/q/QB2T1OH39A==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
-      }
-    },
-    "@babel/plugin-proposal-numeric-separator": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.13.tgz",
-      "integrity": "sha512-O1jFia9R8BUCl3ZGB7eitaAPu62TXJRHn7rh+ojNERCFyqRwJMTmhz+tJ+k0CwI6CLjX/ee4qW74FSqlq9I35w==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13",
-        "@babel/plugin-syntax-numeric-separator": "^7.10.4"
-      }
-    },
-    "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.13.8.tgz",
-      "integrity": "sha512-DhB2EuB1Ih7S3/IRX5AFVgZ16k3EzfRbq97CxAVI1KSYcW+lexV8VZb7G7L8zuPVSdQMRn0kiBpf/Yzu9ZKH0g==",
-      "dev": true,
-      "requires": {
-        "@babel/compat-data": "^7.13.8",
-        "@babel/helper-compilation-targets": "^7.13.8",
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-transform-parameters": "^7.13.0"
-      }
-    },
-    "@babel/plugin-proposal-optional-catch-binding": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.13.8.tgz",
-      "integrity": "sha512-0wS/4DUF1CuTmGo+NiaHfHcVSeSLj5S3e6RivPTg/2k3wOv3jO35tZ6/ZWsQhQMvdgI7CwphjQa/ccarLymHVA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
-      }
-    },
-    "@babel/plugin-proposal-optional-chaining": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.13.8.tgz",
-      "integrity": "sha512-hpbBwbTgd7Cz1QryvwJZRo1U0k1q8uyBmeXOSQUjdg/A2TASkhR/rz7AyqZ/kS8kbpsNA80rOYbxySBJAqmhhQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.12.1",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3"
-      }
-    },
-    "@babel/plugin-proposal-private-methods": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.13.0.tgz",
-      "integrity": "sha512-MXyyKQd9inhx1kDYPkFRVOBXQ20ES8Pto3T7UZ92xj2mY0EVD8oAVzeyYuVfy/mxAdTSIayOvg+aVzcHV2bn6Q==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.13.0",
-        "@babel/helper-plugin-utils": "^7.13.0"
-      }
-    },
-    "@babel/plugin-proposal-unicode-property-regex": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.12.13.tgz",
-      "integrity": "sha512-XyJmZidNfofEkqFV5VC/bLabGmO5QzenPO/YOfGuEbgU+2sSwMmio3YLb4WtBgcmmdwZHyVyv8on77IUjQ5Gvg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.12.13",
-        "@babel/helper-plugin-utils": "^7.12.13"
-      }
-    },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
@@ -826,24 +491,6 @@
         "@babel/helper-plugin-utils": "^7.12.13"
       }
     },
-    "@babel/plugin-syntax-dynamic-import": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
-      "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      }
-    },
-    "@babel/plugin-syntax-export-namespace-from": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
-      "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3"
-      }
-    },
     "@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
@@ -860,15 +507,6 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
-      }
-    },
-    "@babel/plugin-syntax-jsx": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.12.13.tgz",
-      "integrity": "sha512-d4HM23Q1K7oq/SLNmG6mRt85l2csmQ0cHRaxRXjKW0YFdEXqlZ5kzFQKH5Uc3rDJECgu+yCRgPkG04Mm98R/1g==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13"
       }
     },
     "@babel/plugin-syntax-logical-assignment-operators": {
@@ -934,492 +572,21 @@
         "@babel/helper-plugin-utils": "^7.12.13"
       }
     },
-    "@babel/plugin-transform-arrow-functions": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.13.0.tgz",
-      "integrity": "sha512-96lgJagobeVmazXFaDrbmCLQxBysKu7U6Do3mLsx27gf5Dk85ezysrs2BZUpXD703U/Su1xTBDxxar2oa4jAGg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.13.0"
-      }
-    },
-    "@babel/plugin-transform-async-to-generator": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.13.0.tgz",
-      "integrity": "sha512-3j6E004Dx0K3eGmhxVJxwwI89CTJrce7lg3UrtFuDAVQ/2+SJ/h/aSFOeE6/n0WB1GsOffsJp6MnPQNQ8nmwhg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-module-imports": "^7.12.13",
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/helper-remap-async-to-generator": "^7.13.0"
-      }
-    },
-    "@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.12.13.tgz",
-      "integrity": "sha512-zNyFqbc3kI/fVpqwfqkg6RvBgFpC4J18aKKMmv7KdQ/1GgREapSJAykLMVNwfRGO3BtHj3YQZl8kxCXPcVMVeg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13"
-      }
-    },
-    "@babel/plugin-transform-block-scoping": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.13.tgz",
-      "integrity": "sha512-Pxwe0iqWJX4fOOM2kEZeUuAxHMWb9nK+9oh5d11bsLoB0xMg+mkDpt0eYuDZB7ETrY9bbcVlKUGTOGWy7BHsMQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13"
-      }
-    },
-    "@babel/plugin-transform-classes": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.13.0.tgz",
-      "integrity": "sha512-9BtHCPUARyVH1oXGcSJD3YpsqRLROJx5ZNP6tN5vnk17N0SVf9WCtf8Nuh1CFmgByKKAIMstitKduoCmsaDK5g==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-annotate-as-pure": "^7.12.13",
-        "@babel/helper-function-name": "^7.12.13",
-        "@babel/helper-optimise-call-expression": "^7.12.13",
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/helper-replace-supers": "^7.13.0",
-        "@babel/helper-split-export-declaration": "^7.12.13",
-        "globals": "^11.1.0"
-      }
-    },
-    "@babel/plugin-transform-computed-properties": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.13.0.tgz",
-      "integrity": "sha512-RRqTYTeZkZAz8WbieLTvKUEUxZlUTdmL5KGMyZj7FnMfLNKV4+r5549aORG/mgojRmFlQMJDUupwAMiF2Q7OUg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.13.0"
-      }
-    },
-    "@babel/plugin-transform-destructuring": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.13.0.tgz",
-      "integrity": "sha512-zym5em7tePoNT9s964c0/KU3JPPnuq7VhIxPRefJ4/s82cD+q1mgKfuGRDMCPL0HTyKz4dISuQlCusfgCJ86HA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.13.0"
-      }
-    },
-    "@babel/plugin-transform-dotall-regex": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.12.13.tgz",
-      "integrity": "sha512-foDrozE65ZFdUC2OfgeOCrEPTxdB3yjqxpXh8CH+ipd9CHd4s/iq81kcUpyH8ACGNEPdFqbtzfgzbT/ZGlbDeQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.12.13",
-        "@babel/helper-plugin-utils": "^7.12.13"
-      }
-    },
-    "@babel/plugin-transform-duplicate-keys": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.12.13.tgz",
-      "integrity": "sha512-NfADJiiHdhLBW3pulJlJI2NB0t4cci4WTZ8FtdIuNc2+8pslXdPtRRAEWqUY+m9kNOk2eRYbTAOipAxlrOcwwQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13"
-      }
-    },
-    "@babel/plugin-transform-exponentiation-operator": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.12.13.tgz",
-      "integrity": "sha512-fbUelkM1apvqez/yYx1/oICVnGo2KM5s63mhGylrmXUxK/IAXSIf87QIxVfZldWf4QsOafY6vV3bX8aMHSvNrA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.12.13",
-        "@babel/helper-plugin-utils": "^7.12.13"
-      }
-    },
-    "@babel/plugin-transform-for-of": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.13.0.tgz",
-      "integrity": "sha512-IHKT00mwUVYE0zzbkDgNRP6SRzvfGCYsOxIRz8KsiaaHCcT9BWIkO+H9QRJseHBLOGBZkHUdHiqj6r0POsdytg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.13.0"
-      }
-    },
-    "@babel/plugin-transform-function-name": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.12.13.tgz",
-      "integrity": "sha512-6K7gZycG0cmIwwF7uMK/ZqeCikCGVBdyP2J5SKNCXO5EOHcqi+z7Jwf8AmyDNcBgxET8DrEtCt/mPKPyAzXyqQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-function-name": "^7.12.13",
-        "@babel/helper-plugin-utils": "^7.12.13"
-      }
-    },
-    "@babel/plugin-transform-literals": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.12.13.tgz",
-      "integrity": "sha512-FW+WPjSR7hiUxMcKqyNjP05tQ2kmBCdpEpZHY1ARm96tGQCCBvXKnpjILtDplUnJ/eHZ0lALLM+d2lMFSpYJrQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13"
-      }
-    },
-    "@babel/plugin-transform-member-expression-literals": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.12.13.tgz",
-      "integrity": "sha512-kxLkOsg8yir4YeEPHLuO2tXP9R/gTjpuTOjshqSpELUN3ZAg2jfDnKUvzzJxObun38sw3wm4Uu69sX/zA7iRvg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13"
-      }
-    },
-    "@babel/plugin-transform-modules-amd": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.13.0.tgz",
-      "integrity": "sha512-EKy/E2NHhY/6Vw5d1k3rgoobftcNUmp9fGjb9XZwQLtTctsRBOTRO7RHHxfIky1ogMN5BxN7p9uMA3SzPfotMQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-module-transforms": "^7.13.0",
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "babel-plugin-dynamic-import-node": "^2.3.3"
-      }
-    },
-    "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.13.8.tgz",
-      "integrity": "sha512-9QiOx4MEGglfYZ4XOnU79OHr6vIWUakIj9b4mioN8eQIoEh+pf5p/zEB36JpDFWA12nNMiRf7bfoRvl9Rn79Bw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-module-transforms": "^7.13.0",
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/helper-simple-access": "^7.12.13",
-        "babel-plugin-dynamic-import-node": "^2.3.3"
-      }
-    },
-    "@babel/plugin-transform-modules-systemjs": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.13.8.tgz",
-      "integrity": "sha512-hwqctPYjhM6cWvVIlOIe27jCIBgHCsdH2xCJVAYQm7V5yTMoilbVMi9f6wKg0rpQAOn6ZG4AOyvCqFF/hUh6+A==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-hoist-variables": "^7.13.0",
-        "@babel/helper-module-transforms": "^7.13.0",
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/helper-validator-identifier": "^7.12.11",
-        "babel-plugin-dynamic-import-node": "^2.3.3"
-      }
-    },
-    "@babel/plugin-transform-modules-umd": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.13.0.tgz",
-      "integrity": "sha512-D/ILzAh6uyvkWjKKyFE/W0FzWwasv6vPTSqPcjxFqn6QpX3u8DjRVliq4F2BamO2Wee/om06Vyy+vPkNrd4wxw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-module-transforms": "^7.13.0",
-        "@babel/helper-plugin-utils": "^7.13.0"
-      }
-    },
-    "@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.12.13.tgz",
-      "integrity": "sha512-Xsm8P2hr5hAxyYblrfACXpQKdQbx4m2df9/ZZSQ8MAhsadw06+jW7s9zsSw6he+mJZXRlVMyEnVktJo4zjk1WA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.12.13"
-      }
-    },
-    "@babel/plugin-transform-new-target": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.12.13.tgz",
-      "integrity": "sha512-/KY2hbLxrG5GTQ9zzZSc3xWiOy379pIETEhbtzwZcw9rvuaVV4Fqy7BYGYOWZnaoXIQYbbJ0ziXLa/sKcGCYEQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13"
-      }
-    },
-    "@babel/plugin-transform-object-super": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.12.13.tgz",
-      "integrity": "sha512-JzYIcj3XtYspZDV8j9ulnoMPZZnF/Cj0LUxPOjR89BdBVx+zYJI9MdMIlUZjbXDX+6YVeS6I3e8op+qQ3BYBoQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13",
-        "@babel/helper-replace-supers": "^7.12.13"
-      }
-    },
-    "@babel/plugin-transform-parameters": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.13.0.tgz",
-      "integrity": "sha512-Jt8k/h/mIwE2JFEOb3lURoY5C85ETcYPnbuAJ96zRBzh1XHtQZfs62ChZ6EP22QlC8c7Xqr9q+e1SU5qttwwjw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.13.0"
-      }
-    },
-    "@babel/plugin-transform-property-literals": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.12.13.tgz",
-      "integrity": "sha512-nqVigwVan+lR+g8Fj8Exl0UQX2kymtjcWfMOYM1vTYEKujeyv2SkMgazf2qNcK7l4SDiKyTA/nHCPqL4e2zo1A==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13"
-      }
-    },
-    "@babel/plugin-transform-react-display-name": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.12.13.tgz",
-      "integrity": "sha512-MprESJzI9O5VnJZrL7gg1MpdqmiFcUv41Jc7SahxYsNP2kDkFqClxxTZq+1Qv4AFCamm+GXMRDQINNn+qrxmiA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13"
-      }
-    },
-    "@babel/plugin-transform-react-jsx": {
-      "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.12.17.tgz",
-      "integrity": "sha512-mwaVNcXV+l6qJOuRhpdTEj8sT/Z0owAVWf9QujTZ0d2ye9X/K+MTOTSizcgKOj18PGnTc/7g1I4+cIUjsKhBcw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-annotate-as-pure": "^7.12.13",
-        "@babel/helper-module-imports": "^7.12.13",
-        "@babel/helper-plugin-utils": "^7.12.13",
-        "@babel/plugin-syntax-jsx": "^7.12.13",
-        "@babel/types": "^7.12.17"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
-          "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
-      }
-    },
-    "@babel/plugin-transform-react-jsx-development": {
-      "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.12.17.tgz",
-      "integrity": "sha512-BPjYV86SVuOaudFhsJR1zjgxxOhJDt6JHNoD48DxWEIxUCAMjV1ys6DYw4SDYZh0b1QsS2vfIA9t/ZsQGsDOUQ==",
-      "dev": true,
-      "requires": {
-        "@babel/plugin-transform-react-jsx": "^7.12.17"
-      }
-    },
-    "@babel/plugin-transform-react-pure-annotations": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.12.1.tgz",
-      "integrity": "sha512-RqeaHiwZtphSIUZ5I85PEH19LOSzxfuEazoY7/pWASCAIBuATQzpSVD+eT6MebeeZT2F4eSL0u4vw6n4Nm0Mjg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-annotate-as-pure": "^7.10.4",
-        "@babel/helper-plugin-utils": "^7.10.4"
-      }
-    },
-    "@babel/plugin-transform-regenerator": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.12.13.tgz",
-      "integrity": "sha512-lxb2ZAvSLyJ2PEe47hoGWPmW22v7CtSl9jW8mingV4H2sEX/JOcrAj2nPuGWi56ERUm2bUpjKzONAuT6HCn2EA==",
-      "dev": true,
-      "requires": {
-        "regenerator-transform": "^0.14.2"
-      }
-    },
-    "@babel/plugin-transform-reserved-words": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.12.13.tgz",
-      "integrity": "sha512-xhUPzDXxZN1QfiOy/I5tyye+TRz6lA7z6xaT4CLOjPRMVg1ldRf0LHw0TDBpYL4vG78556WuHdyO9oi5UmzZBg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13"
-      }
-    },
-    "@babel/plugin-transform-shorthand-properties": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.13.tgz",
-      "integrity": "sha512-xpL49pqPnLtf0tVluuqvzWIgLEhuPpZzvs2yabUHSKRNlN7ScYU7aMlmavOeyXJZKgZKQRBlh8rHbKiJDraTSw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13"
-      }
-    },
-    "@babel/plugin-transform-spread": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.13.0.tgz",
-      "integrity": "sha512-V6vkiXijjzYeFmQTr3dBxPtZYLPcUfY34DebOU27jIl2M/Y8Egm52Hw82CSjjPqd54GTlJs5x+CR7HeNr24ckg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.12.1"
-      }
-    },
-    "@babel/plugin-transform-sticky-regex": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.12.13.tgz",
-      "integrity": "sha512-Jc3JSaaWT8+fr7GRvQP02fKDsYk4K/lYwWq38r/UGfaxo89ajud321NH28KRQ7xy1Ybc0VUE5Pz8psjNNDUglg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13"
-      }
-    },
-    "@babel/plugin-transform-template-literals": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.13.0.tgz",
-      "integrity": "sha512-d67umW6nlfmr1iehCcBv69eSUSySk1EsIS8aTDX4Xo9qajAh6mYtcl4kJrBkGXuxZPEgVr7RVfAvNW6YQkd4Mw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.13.0"
-      }
-    },
-    "@babel/plugin-transform-typeof-symbol": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.13.tgz",
-      "integrity": "sha512-eKv/LmUJpMnu4npgfvs3LiHhJua5fo/CysENxa45YCQXZwKnGCQKAg87bvoqSW1fFT+HA32l03Qxsm8ouTY3ZQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13"
-      }
-    },
-    "@babel/plugin-transform-unicode-escapes": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.12.13.tgz",
-      "integrity": "sha512-0bHEkdwJ/sN/ikBHfSmOXPypN/beiGqjo+o4/5K+vxEFNPRPdImhviPakMKG4x96l85emoa0Z6cDflsdBusZbw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13"
-      }
-    },
-    "@babel/plugin-transform-unicode-regex": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.12.13.tgz",
-      "integrity": "sha512-mDRzSNY7/zopwisPZ5kM9XKCfhchqIYwAKRERtEnhYscZB79VRekuRSoYbN0+KVe3y8+q1h6A4svXtP7N+UoCA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.12.13",
-        "@babel/helper-plugin-utils": "^7.12.13"
-      }
-    },
-    "@babel/preset-env": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.13.8.tgz",
-      "integrity": "sha512-Sso1xOpV4S3ofnxW2DsWTE5ziRk62jEAKLGuQ+EJHC+YHTbFG38QUTixO3JVa1cYET9gkJhO1pMu+/+2dDhKvw==",
-      "dev": true,
-      "requires": {
-        "@babel/compat-data": "^7.13.8",
-        "@babel/helper-compilation-targets": "^7.13.8",
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/helper-validator-option": "^7.12.17",
-        "@babel/plugin-proposal-async-generator-functions": "^7.13.8",
-        "@babel/plugin-proposal-class-properties": "^7.13.0",
-        "@babel/plugin-proposal-dynamic-import": "^7.13.8",
-        "@babel/plugin-proposal-export-namespace-from": "^7.12.13",
-        "@babel/plugin-proposal-json-strings": "^7.13.8",
-        "@babel/plugin-proposal-logical-assignment-operators": "^7.13.8",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.13.8",
-        "@babel/plugin-proposal-numeric-separator": "^7.12.13",
-        "@babel/plugin-proposal-object-rest-spread": "^7.13.8",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.13.8",
-        "@babel/plugin-proposal-optional-chaining": "^7.13.8",
-        "@babel/plugin-proposal-private-methods": "^7.13.0",
-        "@babel/plugin-proposal-unicode-property-regex": "^7.12.13",
-        "@babel/plugin-syntax-async-generators": "^7.8.4",
-        "@babel/plugin-syntax-class-properties": "^7.12.13",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
-        "@babel/plugin-syntax-json-strings": "^7.8.3",
-        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-        "@babel/plugin-syntax-top-level-await": "^7.12.13",
-        "@babel/plugin-transform-arrow-functions": "^7.13.0",
-        "@babel/plugin-transform-async-to-generator": "^7.13.0",
-        "@babel/plugin-transform-block-scoped-functions": "^7.12.13",
-        "@babel/plugin-transform-block-scoping": "^7.12.13",
-        "@babel/plugin-transform-classes": "^7.13.0",
-        "@babel/plugin-transform-computed-properties": "^7.13.0",
-        "@babel/plugin-transform-destructuring": "^7.13.0",
-        "@babel/plugin-transform-dotall-regex": "^7.12.13",
-        "@babel/plugin-transform-duplicate-keys": "^7.12.13",
-        "@babel/plugin-transform-exponentiation-operator": "^7.12.13",
-        "@babel/plugin-transform-for-of": "^7.13.0",
-        "@babel/plugin-transform-function-name": "^7.12.13",
-        "@babel/plugin-transform-literals": "^7.12.13",
-        "@babel/plugin-transform-member-expression-literals": "^7.12.13",
-        "@babel/plugin-transform-modules-amd": "^7.13.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.13.8",
-        "@babel/plugin-transform-modules-systemjs": "^7.13.8",
-        "@babel/plugin-transform-modules-umd": "^7.13.0",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.12.13",
-        "@babel/plugin-transform-new-target": "^7.12.13",
-        "@babel/plugin-transform-object-super": "^7.12.13",
-        "@babel/plugin-transform-parameters": "^7.13.0",
-        "@babel/plugin-transform-property-literals": "^7.12.13",
-        "@babel/plugin-transform-regenerator": "^7.12.13",
-        "@babel/plugin-transform-reserved-words": "^7.12.13",
-        "@babel/plugin-transform-shorthand-properties": "^7.12.13",
-        "@babel/plugin-transform-spread": "^7.13.0",
-        "@babel/plugin-transform-sticky-regex": "^7.12.13",
-        "@babel/plugin-transform-template-literals": "^7.13.0",
-        "@babel/plugin-transform-typeof-symbol": "^7.12.13",
-        "@babel/plugin-transform-unicode-escapes": "^7.12.13",
-        "@babel/plugin-transform-unicode-regex": "^7.12.13",
-        "@babel/preset-modules": "^0.1.4",
-        "@babel/types": "^7.13.0",
-        "babel-plugin-polyfill-corejs2": "^0.1.4",
-        "babel-plugin-polyfill-corejs3": "^0.1.3",
-        "babel-plugin-polyfill-regenerator": "^0.1.2",
-        "core-js-compat": "^3.9.0",
-        "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
-          "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
-      }
-    },
-    "@babel/preset-modules": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.4.tgz",
-      "integrity": "sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
-        "@babel/plugin-transform-dotall-regex": "^7.4.4",
-        "@babel/types": "^7.4.4",
-        "esutils": "^2.0.2"
-      }
-    },
-    "@babel/preset-react": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.12.13.tgz",
-      "integrity": "sha512-TYM0V9z6Abb6dj1K7i5NrEhA13oS5ujUYQYDfqIBXYHOc2c2VkFgc+q9kyssIyUfy4/hEwqrgSlJ/Qgv8zJLsA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13",
-        "@babel/plugin-transform-react-display-name": "^7.12.13",
-        "@babel/plugin-transform-react-jsx": "^7.12.13",
-        "@babel/plugin-transform-react-jsx-development": "^7.12.12",
-        "@babel/plugin-transform-react-pure-annotations": "^7.12.1"
-      }
-    },
     "@babel/runtime": {
       "version": "7.12.5",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
       "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
       "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "@babel/runtime-corejs3": {
+      "version": "7.13.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.13.9.tgz",
+      "integrity": "sha512-p6WSr71+5u/VBf1KDS/Y4dK3ZwbV+DD6wQO3X2EbUVluEOiyXUk09DzcwSaUH4WomYXrEPC+i2rqzuthhZhOJw==",
+      "dev": true,
+      "requires": {
+        "core-js-pure": "^3.0.0",
         "regenerator-runtime": "^0.13.4"
       }
     },
@@ -2164,6 +1331,156 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@testing-library/dom": {
+      "version": "7.29.6",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.29.6.tgz",
+      "integrity": "sha512-vzTsAXa439ptdvav/4lsKRcGpAQX7b6wBIqia7+iNzqGJ5zjswApxA6jDAsexrc6ue9krWcbh8o+LYkBXW+GCQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^4.2.2",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.4",
+        "lz-string": "^1.4.4",
+        "pretty-format": "^26.6.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@testing-library/jest-dom": {
+      "version": "5.11.9",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.11.9.tgz",
+      "integrity": "sha512-Mn2gnA9d1wStlAIT2NU8J15LNob0YFBVjs2aEQ3j8rsfRQo+lAs7/ui1i2TGaJjapLmuNPLTsrm+nPjmZDwpcQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@types/testing-library__jest-dom": "^5.9.1",
+        "aria-query": "^4.2.2",
+        "chalk": "^3.0.0",
+        "css": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@testing-library/react": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.5.tgz",
+      "integrity": "sha512-yEx7oIa/UWLe2F2dqK0FtMF9sJWNXD+2PPtp39BvE0Kh9MJ9Kl0HrZAgEuhUJR+Lx8Di6Xz+rKwSdEPY2UV8ZQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^7.28.1"
+      }
+    },
+    "@types/aria-query": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.1.tgz",
+      "integrity": "sha512-S6oPal772qJZHoRZLFc/XoZW2gFvwXusYUmXPXkgxJLuEk2vOt7jc4Yo6z/vtI0EBkbPBVrJJ0B+prLIKiWqHg==",
+      "dev": true
+    },
     "@types/babel__core": {
       "version": "7.1.12",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.12.tgz",
@@ -2248,6 +1565,16 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/jest": {
+      "version": "26.0.20",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.20.tgz",
+      "integrity": "sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^26.0.0",
+        "pretty-format": "^26.0.0"
+      }
+    },
     "@types/node": {
       "version": "14.14.31",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
@@ -2299,6 +1626,15 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
       "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
       "dev": true
+    },
+    "@types/testing-library__jest-dom": {
+      "version": "5.9.5",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.5.tgz",
+      "integrity": "sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==",
+      "dev": true,
+      "requires": {
+        "@types/jest": "*"
+      }
     },
     "@types/warning": {
       "version": "3.0.0",
@@ -2490,6 +1826,16 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.10.2",
+        "@babel/runtime-corejs3": "^7.10.2"
       }
     },
     "arr-diff": {
@@ -2695,15 +2041,6 @@
         }
       }
     },
-    "babel-plugin-dynamic-import-node": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
-      "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
-      "dev": true,
-      "requires": {
-        "object.assign": "^4.1.0"
-      }
-    },
     "babel-plugin-istanbul": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
@@ -2727,36 +2064,6 @@
         "@babel/types": "^7.3.3",
         "@types/babel__core": "^7.0.0",
         "@types/babel__traverse": "^7.0.6"
-      }
-    },
-    "babel-plugin-polyfill-corejs2": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.1.8.tgz",
-      "integrity": "sha512-kB5/xNR9GYDuRmVlL9EGfdKBSUVI/9xAU7PCahA/1hbC2Jbmks9dlBBYjHF9IHMNY2jV/G2lIG7z0tJIW27Rog==",
-      "dev": true,
-      "requires": {
-        "@babel/compat-data": "^7.13.0",
-        "@babel/helper-define-polyfill-provider": "^0.1.4",
-        "semver": "^6.1.1"
-      }
-    },
-    "babel-plugin-polyfill-corejs3": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.1.6.tgz",
-      "integrity": "sha512-IkYhCxPrjrUWigEmkMDXYzM5iblzKCdCD8cZrSAkQOyhhJm26DcG+Mxbx13QT//Olkpkg/AlRdT2L+Ww4Ciphw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-define-polyfill-provider": "^0.1.4",
-        "core-js-compat": "^3.8.1"
-      }
-    },
-    "babel-plugin-polyfill-regenerator": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.1.5.tgz",
-      "integrity": "sha512-EyhBA6uN94W97lR7ecQVTvH9F5tIIdEw3ZqHuU4zekMlW82k5cXNXniiB7PRxQm06BqAjVr4sDT1mOy4RcphIA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-define-polyfill-provider": "^0.1.4"
       }
     },
     "babel-plugin-syntax-jsx": {
@@ -3080,16 +2387,6 @@
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         }
-      }
-    },
-    "call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
       }
     },
     "callsites": {
@@ -3488,36 +2785,11 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
-    "core-js-compat": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.9.0.tgz",
-      "integrity": "sha512-YK6fwFjCOKWwGnjFUR3c544YsnA/7DoLL0ysncuOJ4pwbriAtOpvM2bygdlcXbvQCQZ7bBU9CL4t7tGl7ETRpQ==",
-      "dev": true,
-      "requires": {
-        "browserslist": "^4.16.3",
-        "semver": "7.0.0"
-      },
-      "dependencies": {
-        "browserslist": {
-          "version": "4.16.3",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
-          "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
-          "dev": true,
-          "requires": {
-            "caniuse-lite": "^1.0.30001181",
-            "colorette": "^1.2.1",
-            "electron-to-chromium": "^1.3.649",
-            "escalade": "^3.1.1",
-            "node-releases": "^1.1.70"
-          }
-        },
-        "semver": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-          "dev": true
-        }
-      }
+    "core-js-pure": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.9.1.tgz",
+      "integrity": "sha512-laz3Zx0avrw9a4QEIdmIblnVuJz8W51leY9iLThatCsFawWxC3sE4guASC78JbCin+DkwMpCdp1AVAuzL/GN7A==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -3613,6 +2885,29 @@
         "public-encrypt": "^4.0.0",
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
+      }
+    },
+    "css": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
+      "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.4",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map-resolve": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+          "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+          "dev": true,
+          "requires": {
+            "atob": "^2.1.2",
+            "decode-uri-component": "^0.2.0"
+          }
+        }
       }
     },
     "css.escape": {
@@ -3811,15 +3106,6 @@
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
       "dev": true
     },
-    "define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
-      "requires": {
-        "object-keys": "^1.0.12"
-      }
-    },
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
@@ -3927,6 +3213,12 @@
           "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
         }
       }
+    },
+    "dom-accessibility-api": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz",
+      "integrity": "sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==",
+      "dev": true
     },
     "dom-helpers": {
       "version": "5.2.0",
@@ -4549,17 +3841,6 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
-    "get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
-      }
-    },
     "get-own-enumerable-property-symbols": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
@@ -4663,6 +3944,12 @@
         "har-schema": "^2.0.0"
       }
     },
+    "harmony-reflect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.1.tgz",
+      "integrity": "sha512-WJTeyp0JzGtHcuMsi7rw2VwtkvLa+JyfEKJCFyfcS0+CDkjQ5lHPu7zEhFZP+PDSRrEgXa5Ah0l1MbgbE41XjA==",
+      "dev": true
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -4676,12 +3963,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-    },
-    "has-symbols": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-      "dev": true
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -4970,6 +4251,15 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=",
+      "dev": true,
+      "requires": {
+        "harmony-reflect": "^1.4.6"
       }
     },
     "ieee754": {
@@ -6942,12 +6232,6 @@
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.20.tgz",
       "integrity": "sha512-JD1COMZsq8maT6mnuz1UMV0jvYD0E0aUsSOdrr1/nAG3dhqQXwRRgeW0cSqH1U43INKcqxaiVIQNOUDld7gRDA=="
     },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-      "dev": true
-    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -7106,6 +6390,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "dev": true
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -7239,6 +6529,12 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
       "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
       "optional": true
+    },
+    "min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -7686,12 +6982,6 @@
         }
       }
     },
-    "object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
-    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -7707,18 +6997,6 @@
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         }
-      }
-    },
-    "object.assign": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "has-symbols": "^1.0.1",
-        "object-keys": "^1.1.1"
       }
     },
     "object.pick": {
@@ -8414,34 +7692,20 @@
         "picomatch": "^2.2.1"
       }
     },
-    "regenerate": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
-      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
-      "dev": true
-    },
-    "regenerate-unicode-properties": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
-      "integrity": "sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==",
+    "redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
       "dev": true,
       "requires": {
-        "regenerate": "^1.4.0"
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
       }
     },
     "regenerator-runtime": {
       "version": "0.13.7",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
       "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-    },
-    "regenerator-transform": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
-      "integrity": "sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.8.4"
-      }
     },
     "regex-not": {
       "version": "1.0.2",
@@ -8451,43 +7715,6 @@
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
-      }
-    },
-    "regexpu-core": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.1.tgz",
-      "integrity": "sha512-ywH2VUraA44DZQuRKzARmw6S66mr48pQVva4LBeRhcOltJ6hExvWly5ZjFLYo67xbIxb6W1q4bAGtgfEl20zfQ==",
-      "dev": true,
-      "requires": {
-        "regenerate": "^1.4.0",
-        "regenerate-unicode-properties": "^8.2.0",
-        "regjsgen": "^0.5.1",
-        "regjsparser": "^0.6.4",
-        "unicode-match-property-ecmascript": "^1.0.4",
-        "unicode-match-property-value-ecmascript": "^1.2.0"
-      }
-    },
-    "regjsgen": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
-      "integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==",
-      "dev": true
-    },
-    "regjsparser": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.7.tgz",
-      "integrity": "sha512-ib77G0uxsA2ovgiYbCVGx4Pv3PSttAx2vIwidqQzbL2U5S4Q+j00HdSAneSBuyVcMvEnTXMjiGgB+DlXozVhpQ==",
-      "dev": true,
-      "requires": {
-        "jsesc": "~0.5.0"
-      },
-      "dependencies": {
-        "jsesc": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-          "dev": true
-        }
       }
     },
     "remove-trailing-separator": {
@@ -9624,6 +8851,15 @@
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true
+    },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
     },
     "strip-json-comments": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
     ".next/cache"
   ],
   "devDependencies": {
-    "@babel/core": "^7.13.8",
-    "@babel/preset-env": "^7.13.8",
-    "@babel/preset-react": "^7.12.13",
+    "@testing-library/jest-dom": "^5.11.9",
+    "@testing-library/react": "^11.2.5",
     "babel-jest": "^26.6.3",
     "husky": "^4.3.8",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^26.6.3",
     "lint-staged": "^10.5.4",
     "prettier": "^2.2.1",

--- a/pages/questionnaire.js
+++ b/pages/questionnaire.js
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { useRouter } from "next/router";
 import Questionnaire from "../views/questionnaire";
 import { submitQuestionnaire } from "../lib/fetch";
+import { parseCookies } from "nookies";
 var _ = require("lodash");
 
 /**
@@ -36,9 +37,10 @@ const QuestionnaireController = (props) => {
   const submitResponses = async (responses) => {
     let moodName = responses.name;
     let paramResponses = _.omit(responses, ["name"]);
+    const { jwt } = parseCookies();
 
     try {
-      const response = await submitQuestionnaire(moodName, paramResponses);
+      const response = await submitQuestionnaire(jwt, moodName, paramResponses);
       if (response.error !== "") {
         throw response.error;
       }

--- a/tests/Home.test.js
+++ b/tests/Home.test.js
@@ -1,0 +1,102 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from "react";
+import { render } from "@testing-library/react";
+import HomeController from "../pages/index.js";
+
+// A test suite to check the basic functionality of the home page.
+
+// TEST CASE 1: Home page renders moods and user greeting
+test("Home page should render moods and user greeting", () => {
+  const data = {
+    moods: [
+      {
+        mood_name: "Test mood 1",
+        mood_id: 1,
+        playlists: [
+          { id: "6fwIXqpQNiKvR1wWB0wvzp", idx: 1, name: "Playlist 1" },
+          { id: "0z3fVofHoQKNeqZulMexbg", idx: 2, name: "Playlist 2" },
+        ],
+      },
+      { mood_name: "Test! Test!", mood_id: 39, playlists: [] },
+      { mood_name: "1234", mood_id: 40, playlists: [] },
+    ],
+  };
+
+  const { getByText } = render(
+    <HomeController data={data} username="Test Master" jwt="1234" error="" />
+  );
+
+  const mood1 = getByText(/Test mood 1/);
+  expect(mood1).toBeInTheDocument();
+
+  const mood2 = getByText(/Test! Test!/);
+  expect(mood2).toBeInTheDocument();
+
+  const mood3 = getByText(/1234/);
+  expect(mood3).toBeInTheDocument();
+
+  const greeting = getByText(/Welcome, Test Master!/);
+  expect(greeting).toBeInTheDocument();
+});
+
+// TEST CASE 2: Home page renders playlists
+test("Home page should render moods and user greeting", () => {
+  const data = {
+    moods: [
+      {
+        mood_name: "Happy Mood",
+        mood_id: 1,
+        playlists: [
+          { id: "6fwIXqpQNiKvR1wWB0wvzp", idx: 1, name: "Happy Mood 1" },
+          { id: "0z3fVofHoQKNeqZulMexbg", idx: 2, name: "Happy Mood 2" },
+        ],
+      },
+    ],
+  };
+
+  const { getByText } = render(
+    <HomeController data={data} username="Test Master" jwt="1234" error="" />
+  );
+
+  const playlist1 = getByText(/Happy Mood 1/);
+  expect(playlist1).toBeInTheDocument();
+
+  const playlist2 = getByText(/Happy Mood 2/);
+  expect(playlist2).toBeInTheDocument();
+});
+
+// TEST CASE 3: Home page displays error message if input data is malformed
+test("Home page should display error message if input data is malformed", () => {
+  const data = {};
+
+  const { getByText } = render(
+    <HomeController data={data} username="Test Master" jwt="1234" error="" />
+  );
+
+  const error = getByText(
+    /Sorry, we're having trouble accessing your playlists right now. Please try again later./
+  );
+  expect(error).toBeInTheDocument();
+});
+
+// TEST CASE 4: Home page displays error message if one is provided
+test("Home page should display error message if one is provided", () => {
+  const data = {
+    moods: [],
+  };
+
+  const { getByText } = render(
+    <HomeController
+      data={data}
+      username="Test Master"
+      jwt="1234"
+      error="A terrible error happened!"
+    />
+  );
+
+  const error = getByText(/A terrible error happened!/);
+  expect(error).toBeInTheDocument();
+});

--- a/tests/fetch.test.js
+++ b/tests/fetch.test.js
@@ -1,0 +1,310 @@
+import axios from "axios";
+import * as fetch from "../lib/fetch.js";
+
+// A suite of tests to check server response processing in fetch.js
+
+jest.mock("axios");
+
+// TEST CASE 1: fetchUserMoods processes returned data correctly
+test("fetchUserMoods convert mood response correctly", () => {
+  // Mock backend response
+  const axiosResponse = {
+    status: 200,
+    statusText: "OK",
+    data: {
+      created_moods: [
+        {
+          mood_id: 32,
+          mood_name: "Test Mood 1",
+          params: {
+            danceability: [0.0, 1.0, 0.6],
+            energy: [0.0, 1.0, 0.6],
+            instrumentalness: [0.0, 1.0, 0.7],
+            speechiness: [0.0, 1.0, 0.2],
+            valence: [0.0, 1.0, 0.5],
+          },
+        },
+        {
+          mood_id: 39,
+          mood_name: "Test! Test!",
+          params: {
+            danceability: [0.0, 1.0, 0.6],
+            energy: [0.0, 1.0, 0.6],
+            instrumentalness: [0.0, 1.0, 0.7],
+            speechiness: [0.0, 1.0, 0.2],
+            valence: [0.0, 1.0, 0.5],
+          },
+        },
+        {
+          mood_id: 40,
+          mood_name: "1234",
+          params: {
+            danceability: [0.0, 1.0, 0.1],
+            energy: [0.0, 1.0, 0.2],
+            instrumentalness: [0.0, 1.0, 0.3],
+            speechiness: [0.0, 1.0, 0.4],
+            valence: [0.0, 1.0, 0.5],
+          },
+        },
+      ],
+      external_moods: [
+        {
+          mood_id: 30,
+          mood_name: "External mood",
+          params: {
+            danceability: [0.0, 1.0, 0.6],
+            energy: [0.0, 1.0, 0.6],
+            instrumentalness: [0.0, 1.0, 0.7],
+            speechiness: [0.0, 1.0, 0.2],
+            valence: [0.0, 1.0, 0.5],
+          },
+        },
+      ],
+    },
+  };
+  axios.get.mockResolvedValue(axiosResponse);
+
+  const correctOutput = {
+    error: "",
+    moods: [
+      {
+        mood_id: 32,
+        mood_name: "Test Mood 1",
+        params: {
+          danceability: [0.0, 1.0, 0.6],
+          energy: [0.0, 1.0, 0.6],
+          instrumentalness: [0.0, 1.0, 0.7],
+          speechiness: [0.0, 1.0, 0.2],
+          valence: [0.0, 1.0, 0.5],
+        },
+      },
+      {
+        mood_id: 39,
+        mood_name: "Test! Test!",
+        params: {
+          danceability: [0.0, 1.0, 0.6],
+          energy: [0.0, 1.0, 0.6],
+          instrumentalness: [0.0, 1.0, 0.7],
+          speechiness: [0.0, 1.0, 0.2],
+          valence: [0.0, 1.0, 0.5],
+        },
+      },
+      {
+        mood_id: 40,
+        mood_name: "1234",
+        params: {
+          danceability: [0.0, 1.0, 0.1],
+          energy: [0.0, 1.0, 0.2],
+          instrumentalness: [0.0, 1.0, 0.3],
+          speechiness: [0.0, 1.0, 0.4],
+          valence: [0.0, 1.0, 0.5],
+        },
+      },
+      {
+        mood_id: 30,
+        mood_name: "External mood",
+        params: {
+          danceability: [0.0, 1.0, 0.6],
+          energy: [0.0, 1.0, 0.6],
+          instrumentalness: [0.0, 1.0, 0.7],
+          speechiness: [0.0, 1.0, 0.2],
+          valence: [0.0, 1.0, 0.5],
+        },
+      },
+    ],
+  };
+
+  return fetch
+    .fetchUserMoods(123)
+    .then((data) => expect(data).toEqual(correctOutput));
+});
+
+// TEST CASE 2: fetchUserMoods reports error received
+test("fetchUserMoods should report error in API response", () => {
+  // Mock backend response
+  const axiosResponse = {
+    status: 500,
+    statusText: "INTERNAL SERVER ERROR",
+    data: {
+      created_moods: [],
+      external_moods: [],
+      error: "An error occurred",
+    },
+  };
+  axios.get.mockResolvedValue(axiosResponse);
+
+  const correctOutput = {
+    error: "An error occurred",
+    moods: null,
+  };
+
+  return fetch
+    .fetchUserMoods(123)
+    .then((data) => expect(data).toEqual(correctOutput));
+});
+
+// TEST CASE 3: fetchPlaylistsFromMood processes playlists correctly
+test("fetchPlaylistsFromMood should process playlist response correctly", () => {
+  // Mock backend response
+  const axiosResponse = {
+    status: 200,
+    statusText: "OK",
+    data: [
+      {
+        idx: 1,
+        mood_id: 15,
+        uri: "spotify:playlist:0z3fVofHoQKNeqZulMexbg",
+      },
+      {
+        idx: 2,
+        mood_id: 15,
+        uri: "spotify:playlist:5Eij6nP76TtSt10Lwluaob",
+      },
+      {
+        idx: 3,
+        mood_id: 15,
+        uri: "spotify:playlist:1FnGmN4kA2ueEwCqaosVDf",
+      },
+    ],
+  };
+  axios.get.mockResolvedValue(axiosResponse);
+
+  const correctOutput = {
+    error: "",
+    playlists: [
+      {
+        idx: 1,
+        mood_id: 15,
+        uri: "spotify:playlist:0z3fVofHoQKNeqZulMexbg",
+      },
+      {
+        idx: 2,
+        mood_id: 15,
+        uri: "spotify:playlist:5Eij6nP76TtSt10Lwluaob",
+      },
+      {
+        idx: 3,
+        mood_id: 15,
+        uri: "spotify:playlist:1FnGmN4kA2ueEwCqaosVDf",
+      },
+    ],
+  };
+
+  return fetch
+    .fetchPlaylistsFromMood(123, 15)
+    .then((data) => expect(data).toEqual(correctOutput));
+});
+
+// TEST CASE 4:  requestNewPlaylist processes returned playlist correctly
+test(" requestNewPlaylist processes returned playlist correctly", () => {
+  // Mock backend response (sample of playlist response)
+  const axiosResponse = {
+    status: 200,
+    statusText: "OK",
+    data: {
+      idx: 2,
+      mood_id: "15",
+      tracks: [
+        {
+          album: {
+            album_type: "ALBUM",
+            external_urls: {
+              spotify: "https://open.spotify.com/album/3XzbVl7oibSdnmpCGzCK6A",
+            },
+            href: "https://api.spotify.com/v1/albums/3XzbVl7oibSdnmpCGzCK6A",
+            id: "3XzbVl7oibSdnmpCGzCK6A",
+          },
+        },
+        {
+          album: {
+            album_type: "ALBUM",
+            external_urls: {
+              spotify: "https://open.spotify.com/album/2vTelM2ZV20cLPqQwfWhYa",
+            },
+            href: "https://api.spotify.com/v1/albums/2vTelM2ZV20cLPqQwfWhYa",
+            id: "2vTelM2ZV20cLPqQwfWhYa",
+          },
+        },
+      ],
+      uri: "spotify:playlist:1IVSv8wtcuQwLFTUthFfWY",
+    },
+  };
+  axios.get.mockResolvedValue(axiosResponse);
+
+  const correctOutput = {
+    error: "",
+    playlist: {
+      idx: 2,
+      mood_id: "15",
+      tracks: [
+        {
+          album: {
+            album_type: "ALBUM",
+            external_urls: {
+              spotify: "https://open.spotify.com/album/3XzbVl7oibSdnmpCGzCK6A",
+            },
+            href: "https://api.spotify.com/v1/albums/3XzbVl7oibSdnmpCGzCK6A",
+            id: "3XzbVl7oibSdnmpCGzCK6A",
+          },
+        },
+        {
+          album: {
+            album_type: "ALBUM",
+            external_urls: {
+              spotify: "https://open.spotify.com/album/2vTelM2ZV20cLPqQwfWhYa",
+            },
+            href: "https://api.spotify.com/v1/albums/2vTelM2ZV20cLPqQwfWhYa",
+            id: "2vTelM2ZV20cLPqQwfWhYa",
+          },
+        },
+      ],
+      uri: "spotify:playlist:1IVSv8wtcuQwLFTUthFfWY",
+    },
+  };
+
+  return fetch
+    .requestNewPlaylist(123, 15, "mood")
+    .then((data) => expect(data).toEqual(correctOutput));
+});
+
+// TEST CASE 5: submitQuestionnaire processes returned mood correctly
+test("submitQuestionnaire should process returned mood correctly", () => {
+  // Mock backend response
+  const axiosResponse = {
+    status: 200,
+    statusText: "OK",
+    data: {
+      danceability: [0, 1, 0.28],
+      energy: [0, 1, 0.5],
+      instrumentalness: [0, 1, 0.5],
+      mood_id: 50,
+      speechiness: [0, 1, 0.71],
+      valence: [0, 1, 0.5],
+    },
+  };
+  axios.put.mockResolvedValue(axiosResponse);
+
+  const correctOutput = {
+    error: "",
+    data: {
+      danceability: [0, 1, 0.28],
+      energy: [0, 1, 0.5],
+      instrumentalness: [0, 1, 0.5],
+      mood_id: 50,
+      speechiness: [0, 1, 0.71],
+      valence: [0, 1, 0.5],
+    },
+  };
+
+  const questionnaireResponses = {
+    danceability: [0.0, 1.0, 0.28],
+    instrumentalness: [0.0, 1.0, 0.5],
+    speechiness: [0.0, 1.0, 0.71],
+    valence: [0.0, 1.0, 0.5],
+    energy: [0.0, 1.0, 0.5],
+  };
+
+  return fetch
+    .submitQuestionnaire(123, "Test mood", questionnaireResponses)
+    .then((data) => expect(data).toEqual(correctOutput));
+});


### PR DESCRIPTION
This commit adds two suites of frontend tests, which should now run every time Travis runs. One checks that the functions in fetch.js process responses from the server correctly and the other checks that the home page renders the main things correctly. I also had to do some more setup to get the Jest tests to work. Also, I updated the README with some info about our CI/CD processes.